### PR TITLE
Handle empty module records

### DIFF
--- a/build/tealdoc/generator.lua
+++ b/build/tealdoc/generator.lua
@@ -109,7 +109,7 @@ end
 function Generator.categories_for_module_record(item, env)
    local categories_order = {}
    local categories = {}
-   local uncategorized
+   local uncategorized = {}
 
    local categorize = function(child)
       if filter(child, env) then
@@ -121,28 +121,27 @@ function Generator.categories_for_module_record(item, env)
             end
             table.insert(categories[category], child)
          else
-            if not uncategorized then
-               uncategorized = {}
-            end
             table.insert(uncategorized, child)
          end
       end
    end
 
-   for _, child_name in ipairs(item.children) do
-      local child_item = env.registry[child_name]
-      assert(child_item)
-      if child_item.kind == "overloaded" or child_item.kind == "metamethods" then
-         local nested = child_item.children
-         if nested then
-            for _, nested_name in ipairs(nested) do
-               local nested_item = env.registry[nested_name]
-               assert(nested_item)
-               categorize(nested_item)
+   if item.children then
+      for _, child_name in ipairs(item.children) do
+         local child_item = env.registry[child_name]
+         assert(child_item)
+         if child_item.kind == "overloaded" or child_item.kind == "metamethods" then
+            local nested = child_item.children
+            if nested then
+               for _, nested_name in ipairs(nested) do
+                  local nested_item = env.registry[nested_name]
+                  assert(nested_item)
+                  categorize(nested_item)
+               end
             end
+         else
+            categorize(child_item)
          end
-      else
-         categorize(child_item)
       end
    end
 

--- a/spec/generator/categories_spec.lua
+++ b/spec/generator/categories_spec.lua
@@ -1,0 +1,23 @@
+local tealdoc = require("tealdoc")
+local DefaultEnv = require("tealdoc.default_env")
+local Generator = require("tealdoc.generator")
+
+describe("generator categories", function()
+    it("handles an empty module record", function()
+        local env = DefaultEnv.init()
+        tealdoc.process_text([[
+            local record something
+            end
+
+            return something
+        ]], "something.d.tl", env)
+
+        local order, categories = Generator.categories_for_module_record(
+            env.registry["something"],
+            env
+        )
+
+        assert.same({"$uncategorized"}, order)
+        assert.same({}, categories["$uncategorized"])
+    end)
+end)

--- a/src/tealdoc/generator.tl
+++ b/src/tealdoc/generator.tl
@@ -109,7 +109,7 @@ end
 function Generator.categories_for_module_record(item: tealdoc.Item, env: tealdoc.Env): {string}, {string: {tealdoc.Item}}
     local categories_order: {string} = {}
     local categories: {string: {tealdoc.Item}} = {}
-    local uncategorized: {tealdoc.Item}
+    local uncategorized: {tealdoc.Item} = {}
 
     local categorize = function(child: tealdoc.Item)
         if filter(child, env) then
@@ -121,28 +121,27 @@ function Generator.categories_for_module_record(item: tealdoc.Item, env: tealdoc
                 end
                 table.insert(categories[category], child)
             else
-                if not uncategorized then
-                    uncategorized = {}
-                end
                 table.insert(uncategorized, child)
             end
         end
     end
 
-    for _, child_name in ipairs(item.children) do
-        local child_item = env.registry[child_name]
-        assert(child_item)
-        if child_item.kind == "overloaded" or  child_item.kind == "metamethods" then
-            local nested = child_item.children
-            if nested then
-                for _, nested_name in ipairs(nested) do
-                    local nested_item = env.registry[nested_name]
-                    assert(nested_item)
-                    categorize(nested_item)
+    if item.children then
+        for _, child_name in ipairs(item.children) do
+            local child_item = env.registry[child_name]
+            assert(child_item)
+            if child_item.kind == "overloaded" or  child_item.kind == "metamethods" then
+                local nested = child_item.children
+                if nested then
+                    for _, nested_name in ipairs(nested) do
+                        local nested_item = env.registry[nested_name]
+                        assert(nested_item)
+                        categorize(nested_item)
+                    end
                 end
+            else
+                categorize(child_item)
             end
-        else
-            categorize(child_item)
         end
     end
 


### PR DESCRIPTION
Treat missing record children as an empty collection during category generation. Add a regression test for category generation with an empty module record.

Closes #9