### PR TITLE
Render module descriptions in HTML

### DIFF
--- a/build/tealdoc/generator/html/generator.lua
+++ b/build/tealdoc/generator/html/generator.lua
@@ -210,6 +210,11 @@ HTMLGenerator.init = function(output)
          ctx.builder:text("🔗")
          ctx.builder:rawtext("</a>")
          ctx.builder:rawtext("</h1>")
+         if item.text then
+            ctx.builder:paragraph(function()
+               ctx.builder:md(item.text)
+            end)
+         end
          return false
       end
       return true

--- a/spec/generator/html/generator_spec.lua
+++ b/spec/generator/html/generator_spec.lua
@@ -1,0 +1,27 @@
+local HTMLBuilder = require("tealdoc.generator.html.builder")
+local HTMLGenerator = require("tealdoc.generator.html.generator")
+
+describe("HTML generator", function()
+    it("renders a module description", function()
+        local description = "The Tag module renders HTML elements."
+        local generator = HTMLGenerator.init("unused")
+        local builder = HTMLBuilder.init()
+        local ctx = {builder = builder}
+        local item = {
+            kind = "module",
+            name = "Tag",
+            text = description,
+        }
+        local phase = {name = "module_header"}
+
+        local run_default_phase = generator:on_item_phase(
+            item,
+            phase,
+            ctx,
+            {}
+        )
+
+        assert.is_false(run_default_phase)
+        assert.is_truthy(builder:build():find(description, 1, true))
+    end)
+end)

--- a/src/tealdoc/generator/html/generator.tl
+++ b/src/tealdoc/generator/html/generator.tl
@@ -210,6 +210,11 @@ HTMLGenerator.init = function(output: string): Generator.Base
             ctx.builder:text("🔗")
             ctx.builder:rawtext("</a>")
             ctx.builder:rawtext("</h1>")
+            if item.text then
+                ctx.builder:paragraph(function()
+                    ctx.builder:md(item.text)
+                end)
+            end
             return false
         end
         return true


### PR DESCRIPTION
Include parsed module documentation below custom HTML module headings. Add a regression test to ensure the text is not dropped.

Closes #7