### PR TITLE
Preserve newlines in documentation comments

### DIFF
--- a/build/tealdoc/comment_parser.lua
+++ b/build/tealdoc/comment_parser.lua
@@ -73,10 +73,10 @@ function CommentParser.parse_lines(lines, item, env)
          if not item.text then
             item.text = line
          else
-            item.text = item.text .. " " .. line
+            item.text = item.text .. "\n" .. line
          end
       elseif not has_tag and current_context and current_context.description then
-         current_context.description = current_context.description .. " " .. line
+         current_context.description = current_context.description .. "\n" .. line
       end
    end
 

--- a/spec/comment_parser_spec.lua
+++ b/spec/comment_parser_spec.lua
@@ -1,0 +1,46 @@
+local CommentParser = require("tealdoc.comment_parser")
+
+describe("comment parser", function()
+    it("preserves newlines in item descriptions", function()
+        local item = {}
+        local env = {tag_registry = {}}
+
+        CommentParser.parse_lines({
+            "First paragraph.",
+            "",
+            "Second paragraph.",
+        }, item, env)
+
+        assert.equal(
+            "First paragraph.\n\nSecond paragraph.",
+            item.text
+        )
+    end)
+
+    it("preserves newlines in tag descriptions", function()
+        local description
+        local item = {}
+        local env = {
+            tag_registry = {
+                note = {
+                    name = "note",
+                    has_description = true,
+                    handle = function(ctx)
+                        description = ctx.description
+                    end,
+                },
+            },
+        }
+
+        CommentParser.parse_lines({
+            "@note First paragraph.",
+            "",
+            "Second paragraph.",
+        }, item, env)
+
+        assert.equal(
+            "First paragraph.\n\nSecond paragraph.",
+            description
+        )
+    end)
+end)

--- a/src/tealdoc/comment_parser.tl
+++ b/src/tealdoc/comment_parser.tl
@@ -73,10 +73,10 @@ function CommentParser.parse_lines(lines: {string}, item: tealdoc.Item, env: tea
             if not item.text then
                 item.text = line
             else
-                item.text = item.text.." "..line
+                item.text = item.text.."\n"..line
             end
         elseif not has_tag and current_context and current_context.description then
-            current_context.description = current_context.description.." "..line
+            current_context.description = current_context.description.."\n"..line
         end
     end
 


### PR DESCRIPTION
Join documentation and tag-description lines with newline characters so Markdown paragraph boundaries survive parsing. Add regression coverage for both paths.

Closes #6