### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Lua ${{ matrix.lua-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lua-version:
+          - "5.1"
+          - "5.2"
+          - "5.3"
+          - "5.4"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Lua
+        uses: leafo/gh-actions-lua@v13
+        with:
+          luaVersion: ${{ matrix.lua-version }}
+
+      - name: Set up LuaRocks
+        uses: leafo/gh-actions-luarocks@v6
+
+      - name: Install dependencies
+        run: |
+          luarocks make --only-deps tealdoc-dev-1.rockspec
+          luarocks install busted
+
+      - name: Build tealdoc
+        run: |
+          while IFS= read -r source; do
+            output="build/${source#src/}"
+            output="${output%.tl}.lua"
+            mkdir -p "$(dirname "$output")"
+            tl -I src -I types gen "$source" -o "$output"
+          done < <(find src -type f -name '*.tl' | sort)
+          luarocks make tealdoc-dev-1.rockspec
+
+      - name: Run tests
+        run: busted
+
+      - name: Generate docs for a LuaRocks package
+        run: |
+          sample=$(lua -e '
+            for template in package.path:gmatch("[^;]+") do
+              local path = template:gsub("?", "tl")
+              local file = io.open(path, "r")
+              if file then
+                file:close()
+                print((path:gsub("%.lua$", ".tl")))
+                return
+              end
+            end
+            os.exit(1)
+          ')
+          tealdoc md --no-warn-missing --output /tmp/tl-docs.md "$sample"
+          test -s /tmp/tl-docs.md
+          grep -q '^# Module:' /tmp/tl-docs.md

--- a/build/tealdoc/parser/teal.lua
+++ b/build/tealdoc/parser/teal.lua
@@ -516,6 +516,11 @@ local function variable_declarations_visitor(node, state)
          local item
          if decltype and type_is_function(decltype) then
             item = item_for_function_type(decltype, node.kind == "local_declaration" and "local" or "global", "function", state)
+            if decltype.typename == "generic" then
+               local base = decltype.t
+               assert(base.typename == "function")
+               item.location = location_for_type(base)
+            end
             item.is_declaration = true
          elseif typeinfo and typeinfo.t == 0x20 then
             item = item_for_function_typeinfo(typeinfo,

--- a/spec/parser/teal/variables_spec.lua
+++ b/spec/parser/teal/variables_spec.lua
@@ -189,8 +189,8 @@ describe("teal support in tealdoc: variables", function()
                 path = "$test~x",
                 location = {
                     filename = "test.tl",
-                    y = 4,
-                    x = 1,
+                    y = 2,
+                    x = 10,
                 },
                 typeargs = { { name = "T" } },
                 params = { { type = "T" } },
@@ -214,8 +214,8 @@ describe("teal support in tealdoc: variables", function()
                 path = "$test~x",
                 location = {
                     filename = "test.tl",
-                    y = 4,
-                    x = 1,
+                    y = 2,
+                    x = 10,
                 },
                 typeargs = { { name = "T", constraint = "tl.Numeric" } },
                 params = { { type = "T" } },

--- a/src/tealdoc/parser/teal.tl
+++ b/src/tealdoc/parser/teal.tl
@@ -516,6 +516,11 @@ local function variable_declarations_visitor(node: tl.Node, state: VisitState)
             local item: tealdoc.Item
             if decltype and type_is_function(decltype) then
                 item = item_for_function_type(decltype as tl.FunctionType | tl.GenericType, node.kind == "local_declaration" and "local" or "global", "function", state)
+                if decltype is tl.GenericType then
+                    local base = decltype.t
+                    assert(base is tl.FunctionType)
+                    item.location = location_for_type(base)
+                end
                 item.is_declaration = true
             elseif typeinfo and typeinfo.t == 0x20 then -- 0x20 is for function type
                 item = item_for_function_typeinfo(typeinfo,


### PR DESCRIPTION
Test Tealdoc on Lua 5.1 through 5.4. Build and install the rock, run the Busted specs, and generate documentation from the Teal source installed by LuaRocks.

Normalize generic function variable locations so the suite produces consistent results across Lua versions.