### PR TITLE
Fix function field documentation

### DIFF
--- a/build/tealdoc/generator/html/detailed_signature_phase.lua
+++ b/build/tealdoc/generator/html/detailed_signature_phase.lua
@@ -93,9 +93,8 @@ signature = function(ctx, item, indent, force_open)
             ctx.builder:line()
             local child_item = ctx.env.registry[child]
             assert(child_item, "Child item not found: " .. child)
-            assert(child_item.kind == "function", "Expected function item, got: " .. child_item.kind)
             if not ctx.filter or ctx.filter(child_item, ctx.env) then
-               signature(ctx, child_item, indent)
+               assert(signature(ctx, child_item, indent), "Expected signature item, got: " .. child_item.kind)
             end
          end
       end
@@ -117,10 +116,11 @@ signature = function(ctx, item, indent, force_open)
       for i, child in ipairs(item.children) do
          local child_item = ctx.env.registry[child]
          assert(child_item, "Child item not found: " .. child)
-         assert(child_item.kind == "function", "Expected function item, got: " .. child_item.kind)
 
          if not ctx.filter or ctx.filter(child_item, ctx.env) then
-            any_has_signature = any_has_signature or signature(ctx, child_item, indent)
+            local child_has_signature = signature(ctx, child_item, indent)
+            assert(child_has_signature, "Expected signature item, got: " .. child_item.kind)
+            any_has_signature = child_has_signature or any_has_signature
          end
          if i ~= #item.children then
             ctx.builder:line()

--- a/build/tealdoc/parser/teal.lua
+++ b/build/tealdoc/parser/teal.lua
@@ -424,9 +424,11 @@ local function function_visitor(node, state)
       local typenum = typenum_for_node(state.type_report, node.fn_owner)
       local parent_path = typenum and state.typenum_to_path[typenum]
 
-      if not parent_path and node.fn_owner.kind == "identifier" then
+
+      if node.fn_owner.kind == "identifier" or node.fn_owner.kind == "type_identifier" then
          local candidate = state.path .. node.fn_owner.tk
-         if state.env.registry[candidate] then
+         local candidate_item = state.env.registry[candidate]
+         if candidate_item and (not parent_path or candidate_item.kind == "variable") then
             parent_path = candidate
          end
       end

--- a/spec/generator/html/generator_spec.lua
+++ b/spec/generator/html/generator_spec.lua
@@ -1,5 +1,8 @@
 local HTMLBuilder = require("tealdoc.generator.html.builder")
 local HTMLGenerator = require("tealdoc.generator.html.generator")
+local DefaultEnv = require("tealdoc.default_env")
+local detailed_signature_phase = require("tealdoc.generator.html.detailed_signature_phase")
+local tealdoc = require("tealdoc")
 
 describe("HTML generator", function()
     it("renders a module description", function()
@@ -23,5 +26,34 @@ describe("HTML generator", function()
 
         assert.is_false(run_default_phase)
         assert.is_truthy(builder:build():find(description, 1, true))
+    end)
+
+    it("renders overloaded metamethods in detailed signatures", function()
+        local env = DefaultEnv.init()
+        tealdoc.process_text([[
+            global record V
+                metamethod __mul: function(number, number): number
+                metamethod __mul: function(number, table): number
+            end
+        ]], "test.tl", env)
+
+        local builder = HTMLBuilder.init()
+        local ctx = {
+            builder = builder,
+            module_name = "test",
+            path_mode = "relative",
+            env = env,
+            filter = function()
+                return true
+            end,
+        }
+
+        assert.has_no.errors(function()
+            detailed_signature_phase.run(ctx, env.registry["$test~V"])
+        end)
+
+        local html = builder:build()
+        assert.is_truthy(html:find("number, number", 1, true))
+        assert.is_truthy(html:find("number, {&lt;any type&gt; : &lt;any type&gt;}", 1, true))
     end)
 end)

--- a/spec/parser/teal/integration_spec.lua
+++ b/spec/parser/teal/integration_spec.lua
@@ -68,6 +68,25 @@ describe("teal parser integration", function()
         assert.equal("record", registry["test.transform"].visibility)
     end)
 
+    it("matches function aliases assigned through record values", function()
+        local registry = util.registry_for_text([[
+            global type Fun = function(): integer
+
+            global record T
+                fun: Fun
+            end
+
+            local t: T
+
+            t.fun = function(): integer
+                return 1
+            end
+        ]])
+
+        assert.equal("function", registry["$test~T.fun"].kind)
+        assert.equal("record", registry["$test~T.fun"].visibility)
+    end)
+
     it("does not attach separated documentation blocks", function()
         local registry = util.registry_for_text([[
             --- Stale function documentation.

--- a/spec/parser/teal/table_functions_spec.lua
+++ b/spec/parser/teal/table_functions_spec.lua
@@ -97,6 +97,24 @@ describe("should support functions attached to tables", function()
             }
         })
     end)
+    it("should parse multiple functions attached to an inferred table", function()
+        local registry = util.registry_for_text([[
+            local x = {}
+
+            function x.first()
+            end
+
+            function x.second()
+            end
+        ]])
+
+        util.assert_is_same_array(registry["$test~x"].children, {
+            "$test~x.first",
+            "$test~x.second",
+        })
+        assert.equal("function", registry["$test~x.first"].kind)
+        assert.equal("function", registry["$test~x.second"].kind)
+    end)
     it("should parse a function attached to a table via assignment", function()
        util.check_registry([[
             local x = {}

--- a/src/tealdoc/generator/html/detailed_signature_phase.tl
+++ b/src/tealdoc/generator/html/detailed_signature_phase.tl
@@ -93,9 +93,8 @@ signature = function(ctx: Generator.Phase.Context, item: tealdoc.Item, indent?: 
                 ctx.builder:line()
                 local child_item = ctx.env.registry[child]
                 assert(child_item, "Child item not found: " .. child)
-                assert(child_item is tealdoc.FunctionItem, "Expected function item, got: " .. child_item.kind)
                 if not ctx.filter or ctx.filter(child_item, ctx.env) then
-                    signature(ctx, child_item, indent)
+                    assert(signature(ctx, child_item, indent), "Expected signature item, got: " .. child_item.kind)
                 end
             end
         end
@@ -117,10 +116,11 @@ signature = function(ctx: Generator.Phase.Context, item: tealdoc.Item, indent?: 
         for i, child in ipairs(item.children) do
             local child_item = ctx.env.registry[child]
             assert(child_item, "Child item not found: " .. child)
-            assert(child_item is tealdoc.FunctionItem, "Expected function item, got: " .. child_item.kind)
-            
+
             if not ctx.filter or ctx.filter(child_item, ctx.env) then
-                any_has_signature = any_has_signature or signature(ctx, child_item, indent)
+                local child_has_signature = signature(ctx, child_item, indent)
+                assert(child_has_signature, "Expected signature item, got: " .. child_item.kind)
+                any_has_signature = child_has_signature or any_has_signature
             end
             if i ~= #item.children then
                 ctx.builder:line()

--- a/src/tealdoc/parser/teal.tl
+++ b/src/tealdoc/parser/teal.tl
@@ -423,10 +423,12 @@ local function function_visitor(node: tl.Node, state: VisitState)
         assert(node.fn_owner)
         local typenum = typenum_for_node(state.type_report, node.fn_owner)
         local parent_path = typenum and state.typenum_to_path[typenum]
-        -- Current Teal may assign a new type number to the same owner.
-        if not parent_path and node.fn_owner.kind == "identifier" then
+        -- Current Teal may assign a new type number as fields are added to an
+        -- inferred table. Prefer its existing registry entry when available.
+        if node.fn_owner.kind == "identifier" or node.fn_owner.kind == "type_identifier" then
             local candidate = state.path .. node.fn_owner.tk
-            if state.env.registry[candidate] then
+            local candidate_item = state.env.registry[candidate]
+            if candidate_item and (not parent_path or candidate_item is tealdoc.VariableItem) then
                 parent_path = candidate
             end
         end


### PR DESCRIPTION
Track functions added to inferred tables after Teal changes their internal type identity.

Render nested overload groups in detailed HTML signatures and cover all reported examples.

Closes #5.