### PR TITLE
Link nominal type aliases

### DIFF
--- a/build/tealdoc.lua
+++ b/build/tealdoc.lua
@@ -299,6 +299,8 @@ local tealdoc = { Location = {}, Env = {}, Typearg = {}, FunctionItem = { Param 
 
 
 
+
+
 tealdoc.version = "0.3+dev"
 
 function tealdoc.Env.init()

--- a/build/tealdoc/generator.lua
+++ b/build/tealdoc/generator.lua
@@ -80,6 +80,8 @@ local Generator = { Attribute = {}, Base = {} }
 
 
 
+
+
 Generator.attr = function(name)
    return { name = name }
 end

--- a/build/tealdoc/generator/html/builder.lua
+++ b/build/tealdoc/generator/html/builder.lua
@@ -83,6 +83,13 @@ HTMLBuilder.link = function(self, to, ...)
    return self
 end
 
+HTMLBuilder.link_url = function(self, url, ...)
+   self:rawtext("<a href=\"", url, "\">")
+   self:text(...)
+   self:rawtext("</a>")
+   return self
+end
+
 local function escape_html(text)
    local output = text:gsub("([&<>'\"])", {
       ["&"] = "&amp;",

--- a/build/tealdoc/generator/html/generator.lua
+++ b/build/tealdoc/generator/html/generator.lua
@@ -18,7 +18,55 @@ local HTMLGenerator = {}
 
 
 
+
 HTMLGenerator.item_phases = {}
+
+local function parts(path)
+   local output = {}
+   for part in path:gmatch("[^.]+") do
+      table.insert(output, part)
+   end
+   return output
+end
+
+HTMLGenerator.url_for_path = function(path, module_name, env)
+   if not env.registry[path] then
+      return nil
+   end
+
+   local target_module
+   for _, candidate in ipairs(env.modules) do
+      if (path == candidate or path:sub(1, #candidate + 1) == candidate .. ".") and
+         (not target_module or #candidate > #target_module) then
+         target_module = candidate
+      end
+   end
+   if not target_module then
+      return nil
+   elseif target_module == module_name then
+      return "#" .. path
+   end
+
+   local current_parts = parts(module_name)
+   local target_parts = parts(target_module)
+   table.remove(current_parts)
+
+   local common = 0
+   while common < #current_parts and common < #target_parts - 1 and
+      current_parts[common + 1] == target_parts[common + 1] do
+      common = common + 1
+   end
+
+   local relative = {}
+   for _ = common + 1, #current_parts do
+      table.insert(relative, "..")
+   end
+   for i = common + 1, #target_parts do
+      table.insert(relative, target_parts[i])
+   end
+   relative[#relative] = relative[#relative] .. ".html#" .. path
+   return table.concat(relative, "/")
+end
 
 
 
@@ -127,9 +175,12 @@ HTMLGenerator.init = function(output)
 
    local module_name_to_builder = {}
 
-   base.on_context_for_item = function(_, ctx, _, module_name, _)
+   base.on_context_for_item = function(_, ctx, _, module_name, env)
       ctx.builder = module_name_to_builder[module_name]
       ctx.path_mode = "relative"
+      ctx.url_for_path = function(path)
+         return HTMLGenerator.url_for_path(path, module_name, env)
+      end
    end
 
    base.on_category_start = function(_, _, category, ctx, _)

--- a/build/tealdoc/generator/markdown.lua
+++ b/build/tealdoc/generator/markdown.lua
@@ -1,4 +1,4 @@
-local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local io = _tl_compat and _tl_compat.io or io; local table = _tl_compat and _tl_compat.table or table; local type = type; local tealdoc = require("tealdoc")
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local io = _tl_compat and _tl_compat.io or io; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local type = type; local tealdoc = require("tealdoc")
 local Generator = require("tealdoc.generator")
 local log = require("tealdoc.log")
 
@@ -17,6 +17,17 @@ function MarkdownBuilder.init()
 end
 
 
+
+local function escape_html(text)
+   local output = text:gsub("([&<>'\"])", {
+      ["&"] = "&amp;",
+      ["<"] = "&lt;",
+      [">"] = "&gt;",
+      ["'"] = "&#39;",
+      ['"'] = "&quot;",
+   })
+   return output
+end
 
 MarkdownBuilder.h1 = function(self, ...)
    self:rawtext("# ")
@@ -55,21 +66,24 @@ MarkdownBuilder.line = function(self, ...)
 end
 
 MarkdownBuilder.link = function(self, to, ...)
-
+   self:rawtext("<a href=\"#", escape_html(to), "\">")
    self:text(...)
+   self:rawtext("</a>")
    return self
 end
 
-
-local function escape_markdown(text)
-   return text
+MarkdownBuilder.link_url = function(self, url, ...)
+   self:rawtext("<a href=\"", escape_html(url), "\">")
+   self:text(...)
+   self:rawtext("</a>")
+   return self
 end
 
 MarkdownBuilder.text = function(self, ...)
    for i = 1, select("#", ...) do
       local c = select(i, ...)
       if type(c) == "string" then
-         table.insert(self.output, escape_markdown(c))
+         table.insert(self.output, escape_html(c))
       elseif type(c) == "function" then
          c(self)
       end
@@ -104,9 +118,9 @@ MarkdownBuilder.paragraph = function(self, ...)
 end
 
 MarkdownBuilder.code_block = function(self, content)
-   self:rawline("```")
+   self:rawtext("<pre><code>")
    content()
-   self:rawline("```")
+   self:rawline("</code></pre>")
    return self
 end
 MarkdownBuilder.ordered_list = function(self, content)
@@ -173,9 +187,15 @@ MarkdownGenerator.init = function(output)
    local builder = MarkdownBuilder.init()
    local base = Generator.Base.init()
    base.item_phases = MarkdownGenerator.item_phases
-   base.on_context_for_item = function(_, ctx, _, _, _)
+   base.on_item_start = function(_, item, _, _)
+      builder:rawline("<a id=\"", escape_html(item.path), "\"></a>")
+   end
+   base.on_context_for_item = function(_, ctx, _, _, env)
       ctx.builder = builder
       ctx.path_mode = "full"
+      ctx.url_for_path = function(path)
+         return env.registry[path] and "#" .. path or nil
+      end
    end
    base.on_end = function(_, _)
       local file = io.open(output, "w")

--- a/build/tealdoc/generator/signatures.lua
+++ b/build/tealdoc/generator/signatures.lua
@@ -97,7 +97,14 @@ end
 function signatures.for_type(ctx, item)
    ctx.builder:text(attr("name"), visibility(item), item.type_kind, " ", function() ctx.builder:link(item.path, get_name(ctx, item)) end)
    if item.type_kind == "type" then
-      ctx.builder:text(attr("type"), " = ", item.typename)
+      ctx.builder:text(attr("type"), " = ", function()
+         local url = item.alias_target and ctx.url_for_path and ctx.url_for_path(item.alias_target)
+         if url then
+            ctx.builder:link_url(url, item.typename)
+         else
+            ctx.builder:text(item.typename)
+         end
+      end)
    elseif item.typeargs and #item.typeargs > 0 then
       local typeargs = {}
       for _, typearg in ipairs(item.typeargs) do

--- a/build/tealdoc/parser/teal.lua
+++ b/build/tealdoc/parser/teal.lua
@@ -15,6 +15,7 @@ local CommentParser = require("tealdoc.comment_parser")
 
 
 
+
 local function typenum_for_position(report, filename, x, y)
    local rf = report.by_pos[filename]
    if not rf then return end
@@ -495,11 +496,22 @@ local function type_is_function(t)
    return t.typename == "function"
 end
 
+local function required_module(exp)
+   if exp and exp.kind == "op" and exp.e1 and exp.e1.tk == "require" and
+      exp.e2 and exp.e2[1] and exp.e2[1].kind == "string" then
+      return exp.e2[1].conststr
+   end
+end
+
 
 local function variable_declarations_visitor(node, state)
    assert(node.kind == "local_declaration" or node.kind == "global_declaration")
    for i, name in ipairs(node.vars) do
       assert(name.kind == "identifier")
+      local module_name = required_module(node.exps and node.exps[i])
+      if module_name then
+         state.module_aliases[name.tk] = module_name
+      end
 
       if name.f:sub(1, 1) ~= "@" then
          local decltype = node.decltuple.tuple[i]
@@ -549,6 +561,25 @@ end
 
 
 local record_like_visitor
+
+local function alias_target_for_type(t, state)
+   if t.typename == "nominal" and t.names and #t.names > 0 then
+      local module_name = state.module_aliases[t.names[1]]
+      if module_name then
+         local target = module_name
+         for i = 2, #t.names do
+            target = target .. "." .. t.names[i]
+         end
+         return target
+      end
+
+      local name = table.concat(t.names, ".")
+      local candidate = state.path .. name
+      if state.env.registry[candidate] then
+         return candidate
+      end
+   end
+end
 
 local function enum_visitor(t, _, state)
 
@@ -604,6 +635,7 @@ local function typedecl_visitor(name, comments, t, visibility, state)
       visibility = visibility,
       location = location_for_type(t),
       type_kind = typekind,
+      alias_target = typekind == "type" and alias_target_for_type(def, state) or nil,
    }
    process_comments(comments, item, state.env)
 
@@ -1045,6 +1077,7 @@ function TealParser:process(text, path, env)
       module_name = module_name,
       type_report = reporter.tr,
       typenum_to_path = self.typenum_to_path,
+      module_aliases = {},
       parent_item = module_item,
       module_item_typeid = result.type.typeid,
    }

--- a/spec/generator/html/generator_spec.lua
+++ b/spec/generator/html/generator_spec.lua
@@ -56,4 +56,43 @@ describe("HTML generator", function()
         assert.is_truthy(html:find("number, number", 1, true))
         assert.is_truthy(html:find("number, {&lt;any type&gt; : &lt;any type&gt;}", 1, true))
     end)
+
+    it("links type aliases to declarations in other modules", function()
+        local env = DefaultEnv.init()
+        env.modules = {"tecs.init", "tecs.types"}
+        env.registry["tecs.types.components.TagComponentOptions"] = {
+            kind = "type",
+            type_kind = "interface",
+            name = "TagComponentOptions",
+            path = "tecs.types.components.TagComponentOptions",
+            visibility = "record",
+        }
+        local item = {
+            kind = "type",
+            type_kind = "type",
+            name = "TagComponentOptions",
+            path = "tecs.init.TagComponentOptions",
+            visibility = "record",
+            typename = "types.components.TagComponentOptions",
+            alias_target = "tecs.types.components.TagComponentOptions",
+        }
+        local builder = HTMLBuilder.init()
+        local ctx = {
+            builder = builder,
+            module_name = "tecs.init",
+            path_mode = "relative",
+            env = env,
+            url_for_path = function(path)
+                return HTMLGenerator.url_for_path(path, "tecs.init", env)
+            end,
+        }
+
+        detailed_signature_phase.run(ctx, item)
+
+        assert.is_truthy(builder:build():find(
+            'href="types.html#tecs.types.components.TagComponentOptions"',
+            1,
+            true
+        ))
+    end)
 end)

--- a/spec/generator/markdown_spec.lua
+++ b/spec/generator/markdown_spec.lua
@@ -1,0 +1,41 @@
+local DefaultEnv = require("tealdoc.default_env")
+local MarkdownGenerator = require("tealdoc.generator.markdown")
+local tealdoc = require("tealdoc")
+
+describe("Markdown generator", function()
+    it("links type aliases to declarations", function()
+        local env = DefaultEnv.init()
+        env.no_warnings_on_missing = true
+        tealdoc.process_text([[
+            local record types
+                interface Options
+                end
+            end
+
+            return types
+        ]], "types.tl", env)
+        tealdoc.process_text([[
+            local types = require("types")
+
+            local record api
+                type Options = types.Options
+            end
+
+            return api
+        ]], "api.tl", env)
+
+        local output = os.tmpname()
+        MarkdownGenerator.init(output):run(env)
+        local file = assert(io.open(output, "r"))
+        local markdown = file:read("*a")
+        file:close()
+        os.remove(output)
+
+        assert.is_truthy(markdown:find('<a id="types.Options"></a>', 1, true))
+        assert.is_truthy(markdown:find(
+            '<a href="#types.Options">types.Options</a>',
+            1,
+            true
+        ))
+    end)
+end)

--- a/spec/parser/teal/integration_spec.lua
+++ b/spec/parser/teal/integration_spec.lua
@@ -87,6 +87,23 @@ describe("teal parser integration", function()
         assert.equal("record", registry["$test~T.fun"].visibility)
     end)
 
+    it("records canonical targets for imported type aliases", function()
+        local registry = util.registry_for_text([[
+            local types = require("tecs.types")
+
+            local record example
+                type Options = types.components.Options
+            end
+
+            return example
+        ]])
+
+        assert.equal(
+            "tecs.types.components.Options",
+            registry["test.Options"].alias_target
+        )
+    end)
+
     it("does not attach separated documentation blocks", function()
         local registry = util.registry_for_text([[
             --- Stale function documentation.

--- a/spec/parser/teal/record_functions_spec.lua
+++ b/spec/parser/teal/record_functions_spec.lua
@@ -1085,7 +1085,8 @@ describe("teal support in tealdoc: record functions", function()
                         y = 4,
                         x = 20,
                     },
-                    typename = "MyRecord"
+                    typename = "MyRecord",
+                    alias_target = "$test~MyRecord"
                 },
                 ["$test~MyRecord.my_function"] = {
                     name = "my_function",
@@ -1152,7 +1153,8 @@ describe("teal support in tealdoc: record functions", function()
                         y = 4,
                         x = 20,
                     },
-                    typename = "MyRecord"
+                    typename = "MyRecord",
+                    alias_target = "$test~MyRecord"
                 },
                 ["$test~MyRecord.my_method"] = {
                     name = "my_method",
@@ -1221,7 +1223,8 @@ describe("teal support in tealdoc: record functions", function()
                         y = 5,
                         x = 20,
                     },
-                    typename = "MyRecord"
+                    typename = "MyRecord",
+                    alias_target = "$test~MyRecord"
                 },
                 ["$test~MyRecord.my_function"] = {
                     name = "my_function",
@@ -1289,7 +1292,8 @@ describe("teal support in tealdoc: record functions", function()
                         y = 5,
                         x = 20,
                     },
-                    typename = "MyRecord"
+                    typename = "MyRecord",
+                    alias_target = "$test~MyRecord"
                 },
                 ["$test~MyRecord.my_method"] = {
                     name = "my_method",
@@ -1693,7 +1697,8 @@ describe("teal support in tealdoc: record functions", function()
                         y = 4,
                         x = 20,
                     },
-                    typename = "MyRecord"
+                    typename = "MyRecord",
+                    alias_target = "$test~MyRecord"
                 },
                 ["$test~MyRecord.my_function"] = {
                     name = "my_function",

--- a/src/tealdoc.tl
+++ b/src/tealdoc.tl
@@ -269,6 +269,8 @@ local record tealdoc
 
         --- The name of the type of the type item.
         typename: string
+        --- Canonical item path for a nominal type alias target, when known.
+        alias_target: string
         --- The type arguments of the type item.
         --- Only used for records and interfaces.
         typeargs: {Typearg}

--- a/src/tealdoc/generator.tl
+++ b/src/tealdoc/generator.tl
@@ -23,6 +23,7 @@ local record Generator
         rawtext: function(self, ...: Content): Builder
         paragraph: function(self, ...: Content): Builder
         link: function(self, to: string, ...: Content): Builder
+        link_url: function(self, url: string, ...: Content): Builder
 
         code_block: function(self, content: Content): Builder
         ordered_list: function(self, content: function(item: function(content: function))): Builder
@@ -51,6 +52,7 @@ local record Generator
             path_mode: PathMode
             env: tealdoc.Env
             filter: function(item: tealdoc.Item, env: tealdoc.Env): boolean
+            url_for_path: function(path: string): string
         end
 
         name: string

--- a/src/tealdoc/generator/html/builder.tl
+++ b/src/tealdoc/generator/html/builder.tl
@@ -83,6 +83,13 @@ HTMLBuilder.link = function(self, to: string, ...: Content): HTMLBuilder
     return self
 end
 
+HTMLBuilder.link_url = function(self, url: string, ...: Content): HTMLBuilder
+    self:rawtext("<a href=\"", url, "\">")
+    self:text(...)
+    self:rawtext("</a>")
+    return self
+end
+
 local function escape_html(text: string): string
     local output = text:gsub("([&<>'\"])", {
         ["&"] = "&amp;",

--- a/src/tealdoc/generator/html/generator.tl
+++ b/src/tealdoc/generator/html/generator.tl
@@ -16,9 +16,57 @@ end
 local record HTMLGenerator
     init: function(ouput: string): Generator.Base
     item_phases: {string: {Generator.Phase}}
+    url_for_path: function(path: string, module_name: string, env: tealdoc.Env): string
 end
 
 HTMLGenerator.item_phases = {}
+
+local function parts(path: string): {string}
+    local output: {string} = {}
+    for part in path:gmatch("[^.]+") do
+        table.insert(output, part)
+    end
+    return output
+end
+
+HTMLGenerator.url_for_path = function(path: string, module_name: string, env: tealdoc.Env): string
+    if not env.registry[path] then
+        return nil
+    end
+
+    local target_module: string
+    for _, candidate in ipairs(env.modules) do
+        if (path == candidate or path:sub(1, #candidate + 1) == candidate .. ".")
+            and (not target_module or #candidate > #target_module) then
+            target_module = candidate
+        end
+    end
+    if not target_module then
+        return nil
+    elseif target_module == module_name then
+        return "#" .. path
+    end
+
+    local current_parts = parts(module_name)
+    local target_parts = parts(target_module)
+    table.remove(current_parts)
+
+    local common = 0
+    while common < #current_parts and common < #target_parts - 1
+        and current_parts[common + 1] == target_parts[common + 1] do
+        common = common + 1
+    end
+
+    local relative: {string} = {}
+    for _ = common + 1, #current_parts do
+        table.insert(relative, "..")
+    end
+    for i = common + 1, #target_parts do
+        table.insert(relative, target_parts[i])
+    end
+    relative[#relative] = relative[#relative] .. ".html#" .. path
+    return table.concat(relative, "/")
+end
 
 local record ModuleNode
     name: string -- top level module name, last element of the path
@@ -127,9 +175,12 @@ HTMLGenerator.init = function(output: string): Generator.Base
 
     local module_name_to_builder: {string: HTMLBuilder} = {}
 
-    base.on_context_for_item = function(_, ctx: Generator.Phase.Context, _: tealdoc.Item, module_name: string, _: tealdoc.Env)
+    base.on_context_for_item = function(_, ctx: Generator.Phase.Context, _: tealdoc.Item, module_name: string, env: tealdoc.Env)
         ctx.builder = module_name_to_builder[module_name]
         ctx.path_mode = "relative"
+        ctx.url_for_path = function(path: string): string
+            return HTMLGenerator.url_for_path(path, module_name, env)
+        end
     end
 
     base.on_category_start = function(_, _: tealdoc.Item, category: string, ctx: Generator.Phase.Context, _: tealdoc.Env)

--- a/src/tealdoc/generator/markdown.tl
+++ b/src/tealdoc/generator/markdown.tl
@@ -18,6 +18,17 @@ end
 
 local type Content = Generator.Builder.Content
 
+local function escape_html(text: string): string
+    local output = text:gsub("([&<>'\"])", {
+        ["&"] = "&amp;",
+        ["<"] = "&lt;",
+        [">"] = "&gt;",
+        ["'"] = "&#39;",
+        ['"'] = "&quot;"
+    })
+    return output
+end
+
 MarkdownBuilder.h1 = function(self, ...: Content): MarkdownBuilder
     self:rawtext("# ")
     self:line(...)
@@ -55,21 +66,24 @@ MarkdownBuilder.line = function(self, ...: Content): MarkdownBuilder
 end
 
 MarkdownBuilder.link = function(self, to: string, ...: Content): MarkdownBuilder
-    -- TODO TODO TODO!!!!
+    self:rawtext("<a href=\"#", escape_html(to), "\">")
     self:text(...)
+    self:rawtext("</a>")
     return self
 end
 
--- TODO: this isn't so trivial, as markdown automatically escapes some characters in codeblocks and it gets messy
-local function escape_markdown(text: string): string
-    return text
+MarkdownBuilder.link_url = function(self, url: string, ...: Content): MarkdownBuilder
+    self:rawtext("<a href=\"", escape_html(url), "\">")
+    self:text(...)
+    self:rawtext("</a>")
+    return self
 end
 
 MarkdownBuilder.text = function(self, ...: Content): MarkdownBuilder
     for i = 1, select("#", ...) do
         local c = select(i, ...)
         if c is string then
-            table.insert(self.output, escape_markdown(c))
+            table.insert(self.output, escape_html(c))
         elseif c is function then
             c(self)
         end
@@ -104,9 +118,9 @@ MarkdownBuilder.paragraph = function(self, ...: Content): MarkdownBuilder
 end
 
 MarkdownBuilder.code_block = function(self, content: function): MarkdownBuilder
-    self:rawline("```")
+    self:rawtext("<pre><code>")
     content()
-    self:rawline("```")
+    self:rawline("</code></pre>")
     return self
 end
 MarkdownBuilder.ordered_list = function(self, content: function(item: function(content: function))): MarkdownBuilder
@@ -173,9 +187,15 @@ MarkdownGenerator.init = function(output: string): Generator.Base
     local builder = MarkdownBuilder.init()
     local base = Generator.Base.init()
     base.item_phases = MarkdownGenerator.item_phases
-    base.on_context_for_item = function(_, ctx: Generator.Phase.Context, _: tealdoc.Item, _: string, _: tealdoc.Env)
+    base.on_item_start = function(_, item: tealdoc.Item, _: string, _: tealdoc.Env)
+        builder:rawline("<a id=\"", escape_html(item.path), "\"></a>")
+    end
+    base.on_context_for_item = function(_, ctx: Generator.Phase.Context, _: tealdoc.Item, _: string, env: tealdoc.Env)
         ctx.builder = builder
         ctx.path_mode = "full"
+        ctx.url_for_path = function(path: string): string
+            return env.registry[path] and "#" .. path or nil
+        end
     end
     base.on_end = function(_, _: tealdoc.Env)
         local file = io.open(output, "w")

--- a/src/tealdoc/generator/signatures.tl
+++ b/src/tealdoc/generator/signatures.tl
@@ -97,7 +97,14 @@ end
 function signatures.for_type(ctx: Generator.Phase.Context, item: tealdoc.TypeItem)
     ctx.builder:text(attr("name"), visibility(item), item.type_kind, " ", function () ctx.builder:link(item.path, get_name(ctx, item)) end)
     if item.type_kind == "type" then
-        ctx.builder:text(attr("type"), " = ", item.typename)
+        ctx.builder:text(attr("type"), " = ", function()
+            local url = item.alias_target and ctx.url_for_path and ctx.url_for_path(item.alias_target)
+            if url then
+                ctx.builder:link_url(url, item.typename)
+            else
+                ctx.builder:text(item.typename)
+            end
+        end)
     elseif item.typeargs and #item.typeargs > 0 then
         local typeargs: {string} = {}
         for _, typearg in ipairs(item.typeargs) do

--- a/src/tealdoc/parser/teal.tl
+++ b/src/tealdoc/parser/teal.tl
@@ -8,6 +8,7 @@ local record VisitState
     module_name: string
     type_report: tl.TypeReport
     typenum_to_path: {integer: string}
+    module_aliases: {string: string}
     parent_item: tealdoc.Item
     module_item_typeid: integer
 end
@@ -495,11 +496,22 @@ local function type_is_function(t: tl.Type): boolean
     return t is tl.FunctionType
 end
 
+local function required_module(exp: tl.Node): string
+    if exp and exp.kind == "op" and exp.e1 and exp.e1.tk == "require"
+        and exp.e2 and exp.e2[1] and exp.e2[1].kind == "string" then
+        return exp.e2[1].conststr
+    end
+end
+
 
 local function variable_declarations_visitor(node: tl.Node, state: VisitState)
     assert(node.kind == "local_declaration" or node.kind == "global_declaration")
     for i, name in ipairs(node.vars) do
         assert(name.kind == "identifier")
+        local module_name = required_module(node.exps and node.exps[i])
+        if module_name then
+            state.module_aliases[name.tk] = module_name
+        end
         -- Synthetic declarations have no entry in the public type report.
         if name.f:sub(1, 1) ~= "@" then
             local decltype = node.decltuple.tuple[i]
@@ -549,6 +561,25 @@ end
 
 
 local record_like_visitor: function(tl.RecordLikeType, tealdoc.TypeItem, VisitState)
+
+local function alias_target_for_type(t: tl.Type, state: VisitState): string
+    if t is tl.NominalType and t.names and #t.names > 0 then
+        local module_name = state.module_aliases[t.names[1]]
+        if module_name then
+            local target = module_name
+            for i = 2, #t.names do
+                target = target .. "." .. t.names[i]
+            end
+            return target
+        end
+
+        local name = table.concat(t.names, ".")
+        local candidate = state.path .. name
+        if state.env.registry[candidate] then
+            return candidate
+        end
+    end
+end
 
 local function enum_visitor(t: tl.EnumType, _: tealdoc.TypeItem, state: VisitState)
     -- Extract enum values into a sorted array for stable order
@@ -604,6 +635,7 @@ local function typedecl_visitor(name: string, comments: {tl.Comment}, t: tl.Type
         visibility = visibility,
         location = location_for_type(t),
         type_kind = typekind,
+        alias_target = typekind == "type" and alias_target_for_type(def, state) or nil,
     }
     process_comments(comments, item, state.env)
 
@@ -1045,6 +1077,7 @@ function TealParser:process(text: string, path: string, env: tealdoc.Env)
         module_name = module_name,
         type_report = reporter.tr,
         typenum_to_path = self.typenum_to_path,
+        module_aliases = {},
         parent_item = module_item,
         module_item_typeid = result.type.typeid
     }


### PR DESCRIPTION
Preserve canonical targets for local and imported aliases.

Render relative links in generated HTML and anchored links in Markdown.