### PR TITLE
Honor Teal project configuration

### DIFF
--- a/build/tealdoc/parser/teal.lua
+++ b/build/tealdoc/parser/teal.lua
@@ -914,7 +914,33 @@ local TealParser = {}
 
 
 
-local function get_sourcedir_from_config()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+local function path_from_config(config_dir, path)
+   if path:match("^[/\\]") or path:match("^%a:[/\\]") then
+      return path
+   end
+   if config_dir == "." then
+      return path
+   end
+   return config_dir .. package.config:sub(1, 1) .. path
+end
+
+local function get_project_config()
    local path_separator = package.config:sub(1, 1)
    local filename = "tlconfig.lua"
    local file = nil
@@ -927,47 +953,125 @@ local function get_sourcedir_from_config()
    end
 
    if not file then
-      log:debug("Could not find tlconfig.tl in the current directory or any parent directory.")
-      return ""
+      log:debug("Could not find tlconfig.lua in the current directory or any parent directory.")
+      return {
+         source_dir = "",
+         module_path = package.path,
+         env_options = {},
+      }
    end
 
+   local config_dir = filename:match("^(.*)[/\\][^/\\]+$") or "."
    local contents = file:read("*a")
+   file:close()
    if contents then
       local load_config, err = load(contents)
       if not load_config then
          log:error("Error loading tlconfig.lua:\n" .. err)
-         return ""
+         return {
+            source_dir = "",
+            module_path = package.path,
+            env_options = {},
+         }
       end
       local ok, config = pcall(load_config)
       if not ok then
          log:error("Error executing tlconfig.lua:\n" .. tostring(config))
-         return ""
+         return {
+            source_dir = "",
+            module_path = package.path,
+            env_options = {},
+         }
       end
 
       if type(config) == "table" then
-         local source_dir = config.source_dir
-         if source_dir and type(source_dir) == "string" then
-            return source_dir
+         local project_config = config
+         local source_dir = ""
+         local configured_source_dir = project_config.source_dir
+         if type(configured_source_dir) == "string" then
+            source_dir = path_from_config(config_dir, configured_source_dir)
          else
             log:debug("tlconfig.lua does not contain 'source_dir' field.")
-            return ""
          end
+
+         local module_paths = {}
+         local include_dirs = project_config.include_dir
+         if include_dirs then
+            for _, include_dir in ipairs(include_dirs) do
+               local path = path_from_config(config_dir, include_dir)
+               table.insert(module_paths, path .. path_separator .. "?.lua")
+               table.insert(module_paths, path .. path_separator .. "?" ..
+               path_separator .. "init.lua")
+            end
+         end
+         table.insert(module_paths, package.path)
+
+         local defaults = {}
+         local feat_arity = project_config.feat_arity
+         if type(feat_arity) == "string" then
+            defaults.feat_arity = feat_arity
+         end
+         local gen_compat = project_config.gen_compat
+         if type(gen_compat) == "string" then
+            defaults.gen_compat = gen_compat
+         end
+         local gen_target = project_config.gen_target
+         if type(gen_target) == "string" then
+            defaults.gen_target = gen_target
+         end
+
+         local predefined_modules
+         local global_env_def = project_config.global_env_def
+         if type(global_env_def) == "string" then
+            predefined_modules = { global_env_def }
+         end
+         local env_options = {
+            defaults = defaults,
+            predefined_modules = predefined_modules,
+         }
+
+         return {
+            source_dir = source_dir,
+            module_path = table.concat(module_paths, ";"),
+            env_options = env_options,
+         }
       else
          log:error("tlconfig.lua did not return a table.")
-         return ""
       end
    end
+
+   return {
+      source_dir = "",
+      module_path = package.path,
+      env_options = {},
+   }
 end
 
 function TealParser.init(source_dir)
-   source_dir = source_dir or get_sourcedir_from_config()
+   local config = get_project_config()
+   source_dir = source_dir or config.source_dir
 
    log:debug("TealParser initialized with source directory: \"" .. tostring(source_dir) .. "\"")
 
+   local old_package_path = package.path
+   local old_tl_path = tl.path
+   package.path = config.module_path
+   tl.path = config.module_path
+   local ok, tl_env, err = pcall(tl.new_env, config.env_options)
+   package.path = old_package_path
+   tl.path = old_tl_path
+   if not ok then
+      error("Could not initialize Teal environment: " .. tostring(tl_env))
+   end
+   if not tl_env then
+      error("Could not initialize Teal environment: " .. tostring(err))
+   end
+
    local parser = {
       source_dir = source_dir,
+      module_path = config.module_path,
       file_extensions = TealParser.file_extensions,
-      tl_env = tl.new_env(),
+      tl_env = tl_env,
       typenum_to_path = {},
    }
    parser.tl_env.report_types = true
@@ -1020,7 +1124,16 @@ end
 
 function TealParser:process(text, path, env)
 
-   local result = tl.check_string(text, self.tl_env, path)
+   local old_package_path = package.path
+   local old_tl_path = tl.path
+   package.path = self.module_path
+   tl.path = self.module_path
+   local ok, result = pcall(tl.check_string, text, self.tl_env, path)
+   package.path = old_package_path
+   tl.path = old_tl_path
+   if not ok then
+      error(result)
+   end
 
    local reporter = result.env.reporter
 

--- a/spec/parser/teal/config_spec.lua
+++ b/spec/parser/teal/config_spec.lua
@@ -1,0 +1,92 @@
+local lfs = require("lfs")
+local TealParser = require("tealdoc.parser.teal")
+local tl = require("tl")
+
+describe("Teal project configuration", function()
+    local original_directory
+    local temporary_directory
+
+    local function write_file(path, contents)
+        local file = assert(io.open(path, "w"))
+        assert(file:write(contents))
+        assert(file:close())
+    end
+
+    before_each(function()
+        original_directory = assert(lfs.currentdir())
+        temporary_directory = os.tmpname()
+        os.remove(temporary_directory)
+        assert(lfs.mkdir(temporary_directory))
+        assert(lfs.mkdir(temporary_directory .. "/definitions"))
+        assert(lfs.mkdir(temporary_directory .. "/source"))
+        assert(lfs.mkdir(temporary_directory .. "/work"))
+
+        write_file(temporary_directory .. "/tlconfig.lua", [[
+return {
+    source_dir = "source",
+    include_dir = {"definitions"},
+    global_env_def = "fixture_globals",
+    feat_arity = "off",
+    gen_compat = "off",
+    gen_target = "5.1",
+}
+]])
+        write_file(temporary_directory .. "/definitions/fixture_globals.d.tl", [[
+global record FixtureGlobal
+    value: string
+end
+]])
+        write_file(temporary_directory .. "/definitions/fixture_dependency.d.tl", [[
+local record FixtureDependency
+    value: string
+end
+
+return FixtureDependency
+]])
+
+        assert(lfs.chdir(temporary_directory .. "/work"))
+    end)
+
+    after_each(function()
+        assert(lfs.chdir(original_directory))
+        os.remove(temporary_directory .. "/definitions/fixture_globals.d.tl")
+        os.remove(temporary_directory .. "/definitions/fixture_dependency.d.tl")
+        os.remove(temporary_directory .. "/tlconfig.lua")
+        assert(lfs.rmdir(temporary_directory .. "/definitions"))
+        assert(lfs.rmdir(temporary_directory .. "/source"))
+        assert(lfs.rmdir(temporary_directory .. "/work"))
+        assert(lfs.rmdir(temporary_directory))
+    end)
+
+    it("applies compiler settings and resolves configured definitions", function()
+        local original_package_path = package.path
+        local original_tl_path = tl.path
+        local parser = TealParser.init()
+        local defaults = parser.tl_env.defaults or parser.tl_env.opts
+
+        assert.equal("../source", parser.source_dir)
+        assert.equal("off", defaults.feat_arity)
+        assert.equal("off", defaults.gen_compat)
+        assert.equal("5.1", defaults.gen_target)
+        assert.is_not_nil(parser.tl_env.globals.FixtureGlobal)
+        assert.equal(original_package_path, package.path)
+        assert.equal(original_tl_path, tl.path)
+
+        local env = {modules = {}, registry = {}}
+        parser:process([[
+local dependency = require("fixture_dependency")
+
+local record Example
+    global: FixtureGlobal
+    dependency: dependency
+end
+
+return Example
+]], "../source/example.tl", env)
+
+        assert.is_not_nil(parser.tl_env.modules.fixture_dependency)
+        assert.is_not_nil(env.registry["$example"])
+        assert.equal(original_package_path, package.path)
+        assert.equal(original_tl_path, tl.path)
+    end)
+end)

--- a/src/tealdoc/parser/teal.tl
+++ b/src/tealdoc/parser/teal.tl
@@ -910,11 +910,37 @@ end
 
 local record TealParser is tealdoc.Parser
     source_dir: string
+    module_path: string
     tl_env: tl.Env
     typenum_to_path: {integer: string}
 end
 
-local function get_sourcedir_from_config(): string
+local record ProjectConfig
+    source_dir: string
+    module_path: string
+    env_options: tl.EnvOptions
+end
+
+local record TealConfigFile
+    source_dir: string
+    include_dir: {string}
+    global_env_def: string
+    feat_arity: string
+    gen_compat: string
+    gen_target: string
+end
+
+local function path_from_config(config_dir: string, path: string): string
+    if path:match("^[/\\]") or path:match("^%a:[/\\]") then
+        return path
+    end
+    if config_dir == "." then
+        return path
+    end
+    return config_dir .. package.config:sub(1, 1) .. path
+end
+
+local function get_project_config(): ProjectConfig
     local path_separator = package.config:sub(1, 1)
     local filename = "tlconfig.lua"
     local file: FILE = nil
@@ -927,47 +953,125 @@ local function get_sourcedir_from_config(): string
     end
 
     if not file then
-        log:debug("Could not find tlconfig.tl in the current directory or any parent directory.")
-        return ""
+        log:debug("Could not find tlconfig.lua in the current directory or any parent directory.")
+        return {
+            source_dir = "",
+            module_path = package.path,
+            env_options = {}
+        }
     end
 
+    local config_dir = filename:match("^(.*)[/\\][^/\\]+$") or "."
     local contents = file:read("*a")
+    file:close()
     if contents then
         local load_config, err = load(contents)
         if not load_config then
             log:error("Error loading tlconfig.lua:\n" .. err)
-            return ""
+            return {
+                source_dir = "",
+                module_path = package.path,
+                env_options = {}
+            }
         end
         local ok, config = pcall(load_config)
         if not ok then
             log:error("Error executing tlconfig.lua:\n" .. tostring(config))
-            return ""
+            return {
+                source_dir = "",
+                module_path = package.path,
+                env_options = {}
+            }
         end
 
         if config is table then
-            local source_dir = config.source_dir
-            if source_dir and source_dir is string then
-                return source_dir
+            local project_config = config as TealConfigFile
+            local source_dir = ""
+            local configured_source_dir = project_config.source_dir
+            if configured_source_dir is string then
+                source_dir = path_from_config(config_dir, configured_source_dir)
             else
                 log:debug("tlconfig.lua does not contain 'source_dir' field.")
-                return ""
             end
+
+            local module_paths: {string} = {}
+            local include_dirs = project_config.include_dir
+            if include_dirs then
+                for _, include_dir in ipairs(include_dirs) do
+                    local path = path_from_config(config_dir, include_dir)
+                    table.insert(module_paths, path .. path_separator .. "?.lua")
+                    table.insert(module_paths, path .. path_separator .. "?" ..
+                        path_separator .. "init.lua")
+                end
+            end
+            table.insert(module_paths, package.path)
+
+            local defaults: any = {}
+            local feat_arity = project_config.feat_arity
+            if feat_arity is string then
+                defaults.feat_arity = feat_arity
+            end
+            local gen_compat = project_config.gen_compat
+            if gen_compat is string then
+                defaults.gen_compat = gen_compat
+            end
+            local gen_target = project_config.gen_target
+            if gen_target is string then
+                defaults.gen_target = gen_target
+            end
+
+            local predefined_modules: {string}
+            local global_env_def = project_config.global_env_def
+            if global_env_def is string then
+                predefined_modules = {global_env_def}
+            end
+            local env_options: tl.EnvOptions = {
+                defaults = defaults,
+                predefined_modules = predefined_modules
+            }
+
+            return {
+                source_dir = source_dir,
+                module_path = table.concat(module_paths, ";"),
+                env_options = env_options
+            }
         else
             log:error("tlconfig.lua did not return a table.")
-            return ""
         end
     end
+
+    return {
+        source_dir = "",
+        module_path = package.path,
+        env_options = {}
+    }
 end
 
 function TealParser.init(source_dir?: string): TealParser
-    source_dir = source_dir or get_sourcedir_from_config()
+    local config = get_project_config()
+    source_dir = source_dir or config.source_dir
 
     log:debug("TealParser initialized with source directory: \"" .. tostring(source_dir).."\"")
 
+    local old_package_path = package.path
+    local old_tl_path = tl.path
+    package.path = config.module_path
+    tl.path = config.module_path
+    local ok, tl_env, err = pcall(tl.new_env, config.env_options)
+    package.path = old_package_path
+    tl.path = old_tl_path
+    if not ok then
+        error("Could not initialize Teal environment: " .. tostring(tl_env))
+    end
+    if not tl_env then
+        error("Could not initialize Teal environment: " .. tostring(err))
+    end
+
     local parser: TealParser = {
         source_dir = source_dir,
+        module_path = config.module_path,
         file_extensions = TealParser.file_extensions,
-        tl_env = tl.new_env(),
+        tl_env = tl_env,
         typenum_to_path = {}
     }
     parser.tl_env.report_types = true
@@ -1020,7 +1124,16 @@ end
 
 function TealParser:process(text: string, path: string, env: tealdoc.Env)
     -- TODO: handle errors
-    local result = tl.check_string(text, self.tl_env, path)
+    local old_package_path = package.path
+    local old_tl_path = tl.path
+    package.path = self.module_path
+    tl.path = self.module_path
+    local ok, result = pcall(tl.check_string, text, self.tl_env, path)
+    package.path = old_package_path
+    tl.path = old_tl_path
+    if not ok then
+        error(result)
+    end
 
     local reporter = result.env.reporter
 


### PR DESCRIPTION
Resolve source and include directories relative to the discovered configuration file. Apply global environment definitions and compiler settings when constructing the Teal environment.

Scope module search paths to parser operations so project settings do not leak into the host process.