### PR TITLE
Document unnamed function type parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ function test.foo(a: integer, b: integer): integer
 end
 ```
 
+Function types used in declarations and record fields may not provide
+parameter names to Tealdoc. Put `@param` tags on the declaration instead of
+placing documentation comments inside the function type:
+
+```
+global record script
+    --- Registers a function to run during mod initialization.
+    --- @param handler The event handler. Passing nil unregisters it.
+    on_init: function(function())
+end
+```
+
+Tealdoc matches tags for unnamed parameters by declaration order and uses each
+tag's parameter name in the generated documentation. When a function type has
+multiple unnamed parameters, write its `@param` tags in the same order.
+
 You can use multiple `@return` tags to document functions with multiple return values:
 
 ```

--- a/build/tealdoc/default_env.lua
+++ b/build/tealdoc/default_env.lua
@@ -56,6 +56,18 @@ function DefaultEnv.init()
 
             if not param then
                for _, p in ipairs(item.params) do
+                  if p.name == nil and p.description == nil then
+                     param = p
+                     break
+                  end
+               end
+            end
+
+
+
+
+            if not param then
+               for _, p in ipairs(item.params) do
                   if p.description == nil then
                      param = p
                      break

--- a/build/tealdoc/parser/teal.lua
+++ b/build/tealdoc/parser/teal.lua
@@ -345,9 +345,15 @@ local function item_for_function_type(t, visibility, kind, state, owner)
    if t.args and #t.args.tuple > 0 then
       item.params = {}
       for i, ar in ipairs(t.args.tuple) do
-         if t.is_method and i == 1 and owner then
+         if t.is_method and i == 1 then
+
+
+
             item.params[i] = {
-               type = typeinfo_to_string(typeinfo_for_type(state.type_report, owner)),
+               name = "self",
+               type = owner and
+               typeinfo_to_string(typeinfo_for_type(state.type_report, owner)) or
+               type_to_string(state.type_report, ar),
             }
          else
             item.params[i] = {

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -49,6 +49,22 @@ function test.foo(a: integer, b: integer): integer
 end
 ```
 
+Function types used in declarations and record fields may not provide
+parameter names to Tealdoc. Put `@param` tags on the declaration instead of
+placing documentation comments inside the function type:
+
+```
+global record script
+    --- Registers a function to run during mod initialization.
+    --- @param handler The event handler. Passing nil unregisters it.
+    on_init: function(function())
+end
+```
+
+Tealdoc matches tags for unnamed parameters by declaration order and uses each
+tag's parameter name in the generated documentation. When a function type has
+multiple unnamed parameters, write its `@param` tags in the same order.
+
 You can use multiple `@return` tags to document functions with multiple return values:
 
 ```

--- a/spec/parser/teal/integration_spec.lua
+++ b/spec/parser/teal/integration_spec.lua
@@ -154,6 +154,38 @@ describe("teal parser integration", function()
         )
     end)
 
+    it("documents a method declared as a record field like its definition", function()
+        local declared = util.registry_for_text([[
+            local record example
+                --- Writes a matrix.
+                --- @param width Viewport width.
+                --- @param height Viewport height.
+                matrix: function(self, width: number, height: number): number
+            end
+        ]])
+
+        local defined = util.registry_for_text([[
+            local record example
+            end
+
+            --- Writes a matrix.
+            --- @param width Viewport width.
+            --- @param height Viewport height.
+            function example:matrix(width: number, height: number): number
+                return width
+            end
+        ]])
+
+        local expected = {
+            { name = "self", type = "example" },
+            { name = "width", type = "number", description = "Viewport width." },
+            { name = "height", type = "number", description = "Viewport height." },
+        }
+
+        assert.is_same(expected, declared["$test~example.matrix"].params)
+        assert.is_same(expected, defined["$test~example.matrix"].params)
+    end)
+
     it("normalizes relative and Windows module paths", function()
         local text = [[
             local record example

--- a/spec/parser/teal/integration_spec.lua
+++ b/spec/parser/teal/integration_spec.lua
@@ -136,6 +136,24 @@ describe("teal parser integration", function()
         assert.equal("The value to use", params[2].description)
     end)
 
+    it("documents unnamed parameters in function-typed fields by tag order", function()
+        local registry = util.registry_for_text([[
+            global record script
+                --- Registers a function to run during mod initialization.
+                --- @param handler The event handler. Passing nil unregisters it.
+                on_init: function(function())
+            end
+        ]])
+
+        local params = registry["$test~script.on_init"].params
+        assert.equal("handler", params[1].name)
+        assert.equal("function()", params[1].type)
+        assert.equal(
+            "The event handler. Passing nil unregisters it.",
+            params[1].description
+        )
+    end)
+
     it("normalizes relative and Windows module paths", function()
         local text = [[
             local record example

--- a/src/tealdoc/default_env.tl
+++ b/src/tealdoc/default_env.tl
@@ -52,8 +52,20 @@ function DefaultEnv.init(): tealdoc.Env
                 end
 
                 -- Function type declarations may not provide parameter names.
-                -- Fall back to their declaration order in that case, and retain
-                -- the mismatch warning for misspelled named parameters.
+                -- Fall back to their declaration order in that case, and only
+                -- over the parameters that still need a name.
+                if not param then
+                    for _, p in ipairs(item.params) do
+                        if p.name == nil and p.description == nil then
+                            param = p
+                            break
+                        end
+                    end
+                end
+
+                -- Every parameter is named, so the tag names one of them
+                -- wrongly. Take the next undocumented parameter to report it
+                -- against, which keeps the mismatch warning below.
                 if not param then
                     for _, p in ipairs(item.params) do
                         if p.description == nil then

--- a/src/tealdoc/parser/teal.tl
+++ b/src/tealdoc/parser/teal.tl
@@ -345,9 +345,15 @@ local function item_for_function_type(t: tl.FunctionType | tl.GenericType, visib
     if t.args and #t.args.tuple > 0 then
         item.params = {}
         for i, ar in ipairs(t.args.tuple) do
-            if t.is_method and i == 1 and owner then
+            if t.is_method and i == 1 then
+                -- The receiver carries no name of its own in a declaration.
+                -- Name it as a definition would, so both spellings of the same
+                -- method document the same parameters.
                 item.params[i] = {
-                    type = typeinfo_to_string(typeinfo_for_type(state.type_report, owner))
+                    name = "self",
+                    type = owner
+                        and typeinfo_to_string(typeinfo_for_type(state.type_report, owner))
+                        or type_to_string(state.type_report, ar)
                 }
             else
                 item.params[i] = {


### PR DESCRIPTION
## Summary

- document how `@param` names unnamed function type parameters
- preserve method receivers when declarations are record fields
- add integration coverage for both forms

## Testing

- `busted spec/parser/teal/integration_spec.lua` (11 successes)

Closes #8