### PR TITLE
Render Markdown signatures as fenced Teal

### DIFF
--- a/build/tealdoc/generator/markdown.lua
+++ b/build/tealdoc/generator/markdown.lua
@@ -6,9 +6,11 @@ local MarkdownBuilder = {}
 
 
 
+
 function MarkdownBuilder.init()
    local builder = {
       output = {},
+      in_code_block = false,
    }
 
    local self = setmetatable(builder, { __index = MarkdownBuilder })
@@ -66,6 +68,10 @@ MarkdownBuilder.line = function(self, ...)
 end
 
 MarkdownBuilder.link = function(self, to, ...)
+   if self.in_code_block then
+      self:text(...)
+      return self
+   end
    self:rawtext("<a href=\"#", escape_html(to), "\">")
    self:text(...)
    self:rawtext("</a>")
@@ -73,6 +79,10 @@ MarkdownBuilder.link = function(self, to, ...)
 end
 
 MarkdownBuilder.link_url = function(self, url, ...)
+   if self.in_code_block then
+      self:text(...)
+      return self
+   end
    self:rawtext("<a href=\"", escape_html(url), "\">")
    self:text(...)
    self:rawtext("</a>")
@@ -83,7 +93,7 @@ MarkdownBuilder.text = function(self, ...)
    for i = 1, select("#", ...) do
       local c = select(i, ...)
       if type(c) == "string" then
-         table.insert(self.output, escape_html(c))
+         table.insert(self.output, self.in_code_block and c or escape_html(c))
       elseif type(c) == "function" then
          c(self)
       end
@@ -118,9 +128,11 @@ MarkdownBuilder.paragraph = function(self, ...)
 end
 
 MarkdownBuilder.code_block = function(self, content)
-   self:rawtext("<pre><code>")
+   self:rawline("```teal")
+   self.in_code_block = true
    content()
-   self:rawline("</code></pre>")
+   self.in_code_block = false
+   self:rawline("```")
    return self
 end
 MarkdownBuilder.ordered_list = function(self, content)

--- a/spec/generator/markdown_spec.lua
+++ b/spec/generator/markdown_spec.lua
@@ -3,7 +3,7 @@ local MarkdownGenerator = require("tealdoc.generator.markdown")
 local tealdoc = require("tealdoc")
 
 describe("Markdown generator", function()
-    it("links type aliases to declarations", function()
+    it("renders signatures as fenced Teal code", function()
         local env = DefaultEnv.init()
         env.no_warnings_on_missing = true
         tealdoc.process_text([[
@@ -19,6 +19,7 @@ describe("Markdown generator", function()
 
             local record api
                 type Options = types.Options
+                identity: function<T>(T): T
             end
 
             return api
@@ -33,9 +34,17 @@ describe("Markdown generator", function()
 
         assert.is_truthy(markdown:find('<a id="types.Options"></a>', 1, true))
         assert.is_truthy(markdown:find(
-            '<a href="#types.Options">types.Options</a>',
+            "```teal\ntype api.Options = types.Options\n```",
             1,
             true
         ))
+        assert.is_truthy(markdown:find(
+            "```teal\nfunction api.identity<T>(T): T\n```",
+            1,
+            true
+        ))
+        assert.is_falsy(markdown:find("<pre><code>", 1, true))
+        assert.is_falsy(markdown:find('<a href="#types.Options">', 1, true))
+        assert.is_falsy(markdown:find("&lt;T&gt;", 1, true))
     end)
 end)

--- a/src/tealdoc/generator/markdown.tl
+++ b/src/tealdoc/generator/markdown.tl
@@ -4,11 +4,13 @@ local log = require("tealdoc.log")
 
 local record MarkdownBuilder is Generator.Builder
     output: {string}
+    in_code_block: boolean
 end
 
 function MarkdownBuilder.init(): MarkdownBuilder
     local builder: MarkdownBuilder = {
-        output = {}
+        output = {},
+        in_code_block = false
     }
 
     local self = setmetatable(builder, {__index = MarkdownBuilder})
@@ -66,6 +68,10 @@ MarkdownBuilder.line = function(self, ...: Content): MarkdownBuilder
 end
 
 MarkdownBuilder.link = function(self, to: string, ...: Content): MarkdownBuilder
+    if self.in_code_block then
+        self:text(...)
+        return self
+    end
     self:rawtext("<a href=\"#", escape_html(to), "\">")
     self:text(...)
     self:rawtext("</a>")
@@ -73,6 +79,10 @@ MarkdownBuilder.link = function(self, to: string, ...: Content): MarkdownBuilder
 end
 
 MarkdownBuilder.link_url = function(self, url: string, ...: Content): MarkdownBuilder
+    if self.in_code_block then
+        self:text(...)
+        return self
+    end
     self:rawtext("<a href=\"", escape_html(url), "\">")
     self:text(...)
     self:rawtext("</a>")
@@ -83,7 +93,7 @@ MarkdownBuilder.text = function(self, ...: Content): MarkdownBuilder
     for i = 1, select("#", ...) do
         local c = select(i, ...)
         if c is string then
-            table.insert(self.output, escape_html(c))
+            table.insert(self.output, self.in_code_block and c or escape_html(c))
         elseif c is function then
             c(self)
         end
@@ -118,9 +128,11 @@ MarkdownBuilder.paragraph = function(self, ...: Content): MarkdownBuilder
 end
 
 MarkdownBuilder.code_block = function(self, content: function): MarkdownBuilder
-    self:rawtext("<pre><code>")
+    self:rawline("```teal")
+    self.in_code_block = true
     content()
-    self:rawline("</code></pre>")
+    self.in_code_block = false
+    self:rawline("```")
     return self
 end
 MarkdownBuilder.ordered_list = function(self, content: function(item: function(content: function))): MarkdownBuilder


### PR DESCRIPTION
## Summary

- emit Markdown signatures as fenced Teal code blocks
- keep signature source unescaped and omit HTML links inside fences
- retain normal HTML escaping and links outside signature blocks
- add coverage for aliases and generic function signatures

## Testing

- make build
- busted -m build/?.lua\;build/?/init.lua spec/generator
- make check-generated-diff BASE_REF=origin/main