### PR TITLE
Structure Markdown references like API pages

### DIFF
--- a/build/tealdoc/default_env.lua
+++ b/build/tealdoc/default_env.lua
@@ -246,6 +246,48 @@ function DefaultEnv.init()
       end,
    }
 
+   local function display_path(ctx, item)
+      if ctx.path_mode == "full" then
+         local path = item.path:gsub("%$[^%.]*%.", "")
+         return path
+      end
+      return strip_module_prefix(item.path, ctx.module_name)
+   end
+
+   local function overload_parent(ctx, item)
+      if not item.parent then
+         return nil
+      end
+      local parent = ctx.env.registry[item.parent]
+      if parent and (parent.kind == "overload" or parent.kind == "overloaded") then
+         return parent
+      end
+      return nil
+   end
+
+   local markdown_header_phase = {
+      name = "markdown_header",
+      run = function(ctx, item)
+         local parent = overload_parent(ctx, item)
+         if parent then
+            if parent.children and parent.children[1] == item.path then
+               ctx.builder:h2(attr("path"), display_path(ctx, parent))
+            end
+            ctx.builder:h3(attr("header"), "Function")
+         else
+            ctx.builder:h2(attr("path"), display_path(ctx, item))
+         end
+      end,
+   }
+
+   local function markdown_section(ctx, item, title)
+      if overload_parent(ctx, item) then
+         ctx.builder:h4(attr("header"), title)
+      else
+         ctx.builder:h3(attr("header"), title)
+      end
+   end
+
    local text_phase = {
       name = "text",
       run = function(ctx, item)
@@ -268,6 +310,15 @@ function DefaultEnv.init()
       end,
    }
 
+   local markdown_function_signature_phase = {
+      name = "markdown_function_signature",
+      run = function(ctx, item)
+         assert(item.kind == "function")
+         markdown_section(ctx, item, "Synopsis")
+         function_signature_phase.run(ctx, item)
+      end,
+   }
+
    local variable_signature_phase = {
       name = "variable_signature",
       run = function(ctx, item)
@@ -280,6 +331,14 @@ function DefaultEnv.init()
       end,
    }
 
+   local markdown_variable_signature_phase = {
+      name = "markdown_variable_signature",
+      run = function(ctx, item)
+         markdown_section(ctx, item, "Synopsis")
+         variable_signature_phase.run(ctx, item)
+      end,
+   }
+
    local type_signature_phase = {
       name = "type_signature",
       run = function(ctx, item)
@@ -289,6 +348,14 @@ function DefaultEnv.init()
             signatures.for_type(ctx, item)
             ctx.builder:line()
          end)
+      end,
+   }
+
+   local markdown_type_signature_phase = {
+      name = "markdown_type_signature",
+      run = function(ctx, item)
+         markdown_section(ctx, item, "Synopsis")
+         type_signature_phase.run(ctx, item)
       end,
    }
 
@@ -352,6 +419,37 @@ function DefaultEnv.init()
       end,
    }
 
+   local markdown_function_params_phase = {
+      name = "markdown_function_params",
+      run = function(ctx, item)
+         assert(item.kind == "function")
+         markdown_section(ctx, item, "Arguments")
+
+         if not item.params or #item.params == 0 then
+            ctx.builder:paragraph("None.")
+            return
+         end
+
+         ctx.builder:unordered_list(function(list_item)
+            for _, param in ipairs(item.params) do
+               list_item(function()
+                  if param.name then
+                     ctx.builder:b(function()
+                        ctx.builder:code(attr("name"), param.name)
+                     end)
+                  end
+                  ctx.builder:text(attr("type"), " (", function() ctx.builder:code(param.type or "?") end, ")")
+                  if param.description then
+                     ctx.builder:text(attr("description"), " — ", function()
+                        ctx.builder:md(param.description)
+                     end)
+                  end
+               end)
+            end
+         end)
+      end,
+   }
+
    local function_returns_phase = {
       name = "function_returns",
       run = function(ctx, item)
@@ -376,10 +474,50 @@ function DefaultEnv.init()
       end,
    }
 
+   local markdown_function_returns_phase = {
+      name = "markdown_function_returns",
+      run = function(ctx, item)
+         assert(item.kind == "function")
+         markdown_section(ctx, item, "Returns")
+
+         if not item.returns or #item.returns == 0 then
+            ctx.builder:paragraph("None.")
+            return
+         end
+
+         ctx.builder:ordered_list(function(list_item)
+            for _, ret in ipairs(item.returns) do
+               list_item(function()
+                  ctx.builder:text(attr("type"), "(", function() ctx.builder:code(ret.type or "?") end, ")")
+                  if ret.description then
+                     ctx.builder:text(attr("description"), " — ", function() ctx.builder:md(ret.description) end)
+                  end
+               end)
+            end
+         end)
+      end,
+   }
+
    MarkdownGenerator.item_phases["module"] = { module_header_phase }
-   MarkdownGenerator.item_phases["function"] = { header_phase, function_signature_phase, text_phase, type_params_phase, function_params_phase, function_returns_phase }
-   MarkdownGenerator.item_phases["variable"] = { header_phase, variable_signature_phase, text_phase }
-   MarkdownGenerator.item_phases["type"] = { header_phase, type_signature_phase, text_phase, type_params_phase }
+   MarkdownGenerator.item_phases["function"] = {
+      markdown_header_phase,
+      text_phase,
+      markdown_function_signature_phase,
+      type_params_phase,
+      markdown_function_params_phase,
+      markdown_function_returns_phase,
+   }
+   MarkdownGenerator.item_phases["variable"] = {
+      markdown_header_phase,
+      text_phase,
+      markdown_variable_signature_phase,
+   }
+   MarkdownGenerator.item_phases["type"] = {
+      markdown_header_phase,
+      text_phase,
+      markdown_type_signature_phase,
+      type_params_phase,
+   }
    MarkdownGenerator.item_phases["enumvalue"] = { header_phase, text_phase }
    MarkdownGenerator.item_phases["markdown"] = { text_phase }
 

--- a/build/tealdoc/default_env.lua
+++ b/build/tealdoc/default_env.lua
@@ -1,4 +1,4 @@
-local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local string = _tl_compat and _tl_compat.string or string; local log = require("tealdoc.log")
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local math = _tl_compat and _tl_compat.math or math; local string = _tl_compat and _tl_compat.string or string; local log = require("tealdoc.log")
 local tealdoc = require("tealdoc")
 local TealParser = require("tealdoc.parser.teal")
 local MarkdownInput = require("tealdoc.parser.markdown")
@@ -265,27 +265,76 @@ function DefaultEnv.init()
       return nil
    end
 
+   local function markdown_item_level(ctx, item)
+      local level = 2
+      local current = item
+      while current.parent do
+         local parent = ctx.env.registry[current.parent]
+         if not parent or parent.kind == "module" or parent.path == ctx.module_name then
+            break
+         end
+         level = math.min(level + 1, 5)
+         current = parent
+      end
+      return level
+   end
+
+   local function markdown_heading(
+      ctx,
+      level,
+      attribute,
+      title)
+
+      if level == 2 then
+         ctx.builder:h2(attribute, title)
+      elseif level == 3 then
+         ctx.builder:h3(attribute, title)
+      elseif level == 4 then
+         ctx.builder:h4(attribute, title)
+      elseif level == 5 then
+         ctx.builder:h5(attribute, title)
+      else
+         ctx.builder:h6(attribute, title)
+      end
+   end
+
    local markdown_header_phase = {
       name = "markdown_header",
       run = function(ctx, item)
          local parent = overload_parent(ctx, item)
          if parent then
             if parent.children and parent.children[1] == item.path then
-               ctx.builder:h2(attr("path"), display_path(ctx, parent))
+               markdown_heading(
+               ctx,
+               markdown_item_level(ctx, parent),
+               attr("path"),
+               display_path(ctx, parent))
+
             end
-            ctx.builder:h3(attr("header"), "Function")
+            markdown_heading(
+            ctx,
+            markdown_item_level(ctx, item),
+            attr("header"),
+            "Function")
+
          else
-            ctx.builder:h2(attr("path"), display_path(ctx, item))
+            markdown_heading(
+            ctx,
+            markdown_item_level(ctx, item),
+            attr("path"),
+            display_path(ctx, item))
+
          end
       end,
    }
 
    local function markdown_section(ctx, item, title)
-      if overload_parent(ctx, item) then
-         ctx.builder:h4(attr("header"), title)
-      else
-         ctx.builder:h3(attr("header"), title)
-      end
+      markdown_heading(
+      ctx,
+      markdown_item_level(ctx, item) + 1,
+      attr("header"),
+      title)
+
    end
 
    local text_phase = {
@@ -310,15 +359,6 @@ function DefaultEnv.init()
       end,
    }
 
-   local markdown_function_signature_phase = {
-      name = "markdown_function_signature",
-      run = function(ctx, item)
-         assert(item.kind == "function")
-         markdown_section(ctx, item, "Synopsis")
-         function_signature_phase.run(ctx, item)
-      end,
-   }
-
    local variable_signature_phase = {
       name = "variable_signature",
       run = function(ctx, item)
@@ -331,14 +371,6 @@ function DefaultEnv.init()
       end,
    }
 
-   local markdown_variable_signature_phase = {
-      name = "markdown_variable_signature",
-      run = function(ctx, item)
-         markdown_section(ctx, item, "Synopsis")
-         variable_signature_phase.run(ctx, item)
-      end,
-   }
-
    local type_signature_phase = {
       name = "type_signature",
       run = function(ctx, item)
@@ -348,14 +380,6 @@ function DefaultEnv.init()
             signatures.for_type(ctx, item)
             ctx.builder:line()
          end)
-      end,
-   }
-
-   local markdown_type_signature_phase = {
-      name = "markdown_type_signature",
-      run = function(ctx, item)
-         markdown_section(ctx, item, "Synopsis")
-         type_signature_phase.run(ctx, item)
       end,
    }
 
@@ -382,6 +406,40 @@ function DefaultEnv.init()
 
                   if typearg.description then
                      ctx.builder:text(attr("description"), " — ", function() ctx.builder:md(typearg.description) end)
+                  end
+               end)
+            end
+         end)
+      end,
+   }
+
+   local markdown_type_params_phase = {
+      name = "markdown_type_params",
+      run = function(ctx, item)
+         assert(item.kind == "type" or item.kind == "function")
+
+         if not item.typeargs or #item.typeargs == 0 then
+            return
+         end
+
+         markdown_section(ctx, item, "Type Parameters")
+         ctx.builder:unordered_list(function(list_item)
+            for _, typearg in ipairs(item.typeargs) do
+               list_item(function()
+                  ctx.builder:b(function()
+                     ctx.builder:code(attr("name"), typearg.name or "?")
+                  end)
+
+                  if typearg.constraint then
+                     ctx.builder:text(attr("constraint"), " ( is ", function()
+                        ctx.builder:code(typearg.constraint)
+                     end, ")")
+                  end
+
+                  if typearg.description then
+                     ctx.builder:text(attr("description"), " — ", function()
+                        ctx.builder:md(typearg.description)
+                     end)
                   end
                end)
             end
@@ -502,23 +560,23 @@ function DefaultEnv.init()
    MarkdownGenerator.item_phases["function"] = {
       markdown_header_phase,
       text_phase,
-      markdown_function_signature_phase,
-      type_params_phase,
+      function_signature_phase,
+      markdown_type_params_phase,
       markdown_function_params_phase,
       markdown_function_returns_phase,
    }
    MarkdownGenerator.item_phases["variable"] = {
       markdown_header_phase,
       text_phase,
-      markdown_variable_signature_phase,
+      variable_signature_phase,
    }
    MarkdownGenerator.item_phases["type"] = {
       markdown_header_phase,
       text_phase,
-      markdown_type_signature_phase,
-      type_params_phase,
+      type_signature_phase,
+      markdown_type_params_phase,
    }
-   MarkdownGenerator.item_phases["enumvalue"] = { header_phase, text_phase }
+   MarkdownGenerator.item_phases["enumvalue"] = { markdown_header_phase, text_phase }
    MarkdownGenerator.item_phases["markdown"] = { text_phase }
 
    HTMLGenerator.item_phases["module"] = { module_header_phase, detailed_signature_phase }

--- a/build/tealdoc/generator/markdown.lua
+++ b/build/tealdoc/generator/markdown.lua
@@ -10,7 +10,7 @@ local MarkdownBuilder = {}
 function MarkdownBuilder.init()
    local builder = {
       output = {},
-      in_code_block = false,
+      in_code = false,
    }
 
    local self = setmetatable(builder, { __index = MarkdownBuilder })
@@ -68,7 +68,7 @@ MarkdownBuilder.line = function(self, ...)
 end
 
 MarkdownBuilder.link = function(self, to, ...)
-   if self.in_code_block then
+   if self.in_code then
       self:text(...)
       return self
    end
@@ -79,7 +79,7 @@ MarkdownBuilder.link = function(self, to, ...)
 end
 
 MarkdownBuilder.link_url = function(self, url, ...)
-   if self.in_code_block then
+   if self.in_code then
       self:text(...)
       return self
    end
@@ -93,7 +93,7 @@ MarkdownBuilder.text = function(self, ...)
    for i = 1, select("#", ...) do
       local c = select(i, ...)
       if type(c) == "string" then
-         table.insert(self.output, self.in_code_block and c or escape_html(c))
+         table.insert(self.output, self.in_code and c or escape_html(c))
       elseif type(c) == "function" then
          c(self)
       end
@@ -124,15 +124,18 @@ MarkdownBuilder.paragraph = function(self, ...)
    self:line()
    self:text(...)
    self:line()
+   self:line()
    return self
 end
 
 MarkdownBuilder.code_block = function(self, content)
+   self:line()
    self:rawline("```teal")
-   self.in_code_block = true
+   self.in_code = true
    content()
-   self.in_code_block = false
+   self.in_code = false
    self:rawline("```")
+   self:line()
    return self
 end
 MarkdownBuilder.ordered_list = function(self, content)
@@ -176,7 +179,10 @@ MarkdownBuilder.i = function(self, ...)
 end
 MarkdownBuilder.code = function(self, ...)
    self:rawtext("`")
+   local was_in_code = self.in_code
+   self.in_code = true
    self:text(...)
+   self.in_code = was_in_code
    self:rawtext("`")
    return self
 end

--- a/build/tealdoc/generator/markdown.lua
+++ b/build/tealdoc/generator/markdown.lua
@@ -6,9 +6,11 @@ local MarkdownBuilder = {}
 
 
 
+
 function MarkdownBuilder.init()
    local builder = {
       output = {},
+      in_code_block = false,
    }
 
    local self = setmetatable(builder, { __index = MarkdownBuilder })
@@ -66,6 +68,10 @@ MarkdownBuilder.line = function(self, ...)
 end
 
 MarkdownBuilder.link = function(self, to, ...)
+   if self.in_code_block then
+      self:text(...)
+      return self
+   end
    self:rawtext("<a href=\"#", escape_html(to), "\">")
    self:text(...)
    self:rawtext("</a>")
@@ -73,6 +79,10 @@ MarkdownBuilder.link = function(self, to, ...)
 end
 
 MarkdownBuilder.link_url = function(self, url, ...)
+   if self.in_code_block then
+      self:text(...)
+      return self
+   end
    self:rawtext("<a href=\"", escape_html(url), "\">")
    self:text(...)
    self:rawtext("</a>")
@@ -83,7 +93,7 @@ MarkdownBuilder.text = function(self, ...)
    for i = 1, select("#", ...) do
       local c = select(i, ...)
       if type(c) == "string" then
-         table.insert(self.output, escape_html(c))
+         table.insert(self.output, self.in_code_block and c or escape_html(c))
       elseif type(c) == "function" then
          c(self)
       end
@@ -118,9 +128,11 @@ MarkdownBuilder.paragraph = function(self, ...)
 end
 
 MarkdownBuilder.code_block = function(self, content)
-   self:rawtext("<pre><code>")
+   self:rawline("```teal")
+   self.in_code_block = true
    content()
-   self:rawline("</code></pre>")
+   self.in_code_block = false
+   self:rawline("```")
    return self
 end
 MarkdownBuilder.ordered_list = function(self, content)

--- a/spec/generator/markdown_spec.lua
+++ b/spec/generator/markdown_spec.lua
@@ -19,7 +19,14 @@ describe("Markdown generator", function()
 
             local record api
                 type Options = types.Options
-                identity: function<T>(T): T
+
+                --- Returns a value unchanged.
+                --- @param value The value to return.
+                --- @return The same value.
+                identity: function<T>(value: T): T
+
+                --- Performs one update.
+                update: function()
             end
 
             return api
@@ -39,10 +46,24 @@ describe("Markdown generator", function()
             true
         ))
         assert.is_truthy(markdown:find(
-            "```teal\nfunction api.identity<T>(T): T\n```",
+            "```teal\nfunction api.identity<T>(value: T): T\n```",
             1,
             true
         ))
+        local identity_heading = assert(markdown:find("## api.identity", 1, true))
+        local identity_text = assert(markdown:find("Returns a value unchanged.", identity_heading, true))
+        local identity_synopsis = assert(markdown:find("### Synopsis", identity_text, true))
+        local identity_arguments = assert(markdown:find("### Arguments", identity_synopsis, true))
+        local identity_returns = assert(markdown:find("### Returns", identity_arguments, true))
+        assert.is_true(identity_heading < identity_text)
+        assert.is_true(identity_text < identity_synopsis)
+        assert.is_true(identity_synopsis < identity_arguments)
+        assert.is_true(identity_arguments < identity_returns)
+        assert.is_truthy(markdown:find(
+            "### Arguments\n\nNone.\n\n### Returns\n\nNone.",
+            assert(markdown:find("## api.update", 1, true)),
+            true
+        ), markdown)
         assert.is_falsy(markdown:find("<pre><code>", 1, true))
         assert.is_falsy(markdown:find('<a href="#types.Options">', 1, true))
         assert.is_falsy(markdown:find("&lt;T&gt;", 1, true))

--- a/spec/generator/markdown_spec.lua
+++ b/spec/generator/markdown_spec.lua
@@ -3,7 +3,7 @@ local MarkdownGenerator = require("tealdoc.generator.markdown")
 local tealdoc = require("tealdoc")
 
 describe("Markdown generator", function()
-    it("links type aliases to declarations", function()
+    it("renders signatures as fenced Teal code", function()
         local env = DefaultEnv.init()
         env.no_warnings_on_missing = true
         tealdoc.process_text([[
@@ -19,6 +19,7 @@ describe("Markdown generator", function()
 
             local record api
                 type Options = types.Options
+                identity: function<T>(T): T
             end
 
             return api
@@ -33,9 +34,17 @@ describe("Markdown generator", function()
 
         assert.is_truthy(markdown:find('<a id="types.Options"></a>', 1, true))
         assert.is_truthy(markdown:find(
-            '<a href="#types.Options">types.Options</a>',
+            "```teal\ntype api.Options = types.Options\n```",
             1,
             true
         ))
+        assert.is_truthy(markdown:find(
+            "```teal\nfunction api.identity<T>(T): T\n```",
+            1,
+            true
+        ))
+        assert.is_falsy(markdown:find("<pre><code>", 1, true))
+        assert.is_falsy(markdown:find('<a href="#types.Options">', 1, true))
+        assert.is_falsy(markdown:find("&lt;T&gt;", 1, true))
     end)
 end)

--- a/spec/generator/markdown_spec.lua
+++ b/spec/generator/markdown_spec.lua
@@ -9,6 +9,7 @@ describe("Markdown generator", function()
         tealdoc.process_text([[
             local record types
                 interface Options
+                    value: string
                 end
             end
 
@@ -52,13 +53,19 @@ describe("Markdown generator", function()
         ))
         local identity_heading = assert(markdown:find("## api.identity", 1, true))
         local identity_text = assert(markdown:find("Returns a value unchanged.", identity_heading, true))
-        local identity_synopsis = assert(markdown:find("### Synopsis", identity_text, true))
-        local identity_arguments = assert(markdown:find("### Arguments", identity_synopsis, true))
+        local identity_signature = assert(markdown:find(
+            "```teal\nfunction api.identity<T>(value: T): T\n```",
+            identity_text,
+            true
+        ))
+        local identity_arguments = assert(markdown:find("### Arguments", identity_signature, true))
         local identity_returns = assert(markdown:find("### Returns", identity_arguments, true))
         assert.is_true(identity_heading < identity_text)
-        assert.is_true(identity_text < identity_synopsis)
-        assert.is_true(identity_synopsis < identity_arguments)
+        assert.is_true(identity_text < identity_signature)
+        assert.is_true(identity_signature < identity_arguments)
         assert.is_true(identity_arguments < identity_returns)
+        assert.is_truthy(markdown:find("### types.Options.value", 1, true))
+        assert.is_falsy(markdown:find("Synopsis", 1, true))
         assert.is_truthy(markdown:find(
             "### Arguments\n\nNone.\n\n### Returns\n\nNone.",
             assert(markdown:find("## api.update", 1, true)),

--- a/src/tealdoc/default_env.tl
+++ b/src/tealdoc/default_env.tl
@@ -246,6 +246,48 @@ function DefaultEnv.init(): tealdoc.Env
         end
     }
 
+    local function display_path(ctx: Generator.Phase.Context, item: tealdoc.Item): string
+        if ctx.path_mode == "full" then
+            local path = item.path:gsub("%$[^%.]*%.", "")
+            return path
+        end
+        return strip_module_prefix(item.path, ctx.module_name)
+    end
+
+    local function overload_parent(ctx: Generator.Phase.Context, item: tealdoc.Item): tealdoc.Item
+        if not item.parent then
+            return nil
+        end
+        local parent = ctx.env.registry[item.parent]
+        if parent and (parent.kind == "overload" or parent.kind == "overloaded") then
+            return parent
+        end
+        return nil
+    end
+
+    local markdown_header_phase: Generator.Phase = {
+        name = "markdown_header",
+        run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
+            local parent = overload_parent(ctx, item)
+            if parent then
+                if parent.children and parent.children[1] == item.path then
+                    ctx.builder:h2(attr("path"), display_path(ctx, parent))
+                end
+                ctx.builder:h3(attr("header"), "Function")
+            else
+                ctx.builder:h2(attr("path"), display_path(ctx, item))
+            end
+        end
+    }
+
+    local function markdown_section(ctx: Generator.Phase.Context, item: tealdoc.Item, title: string)
+        if overload_parent(ctx, item) then
+            ctx.builder:h4(attr("header"), title)
+        else
+            ctx.builder:h3(attr("header"), title)
+        end
+    end
+
     local text_phase: Generator.Phase = {
         name = "text",
         run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
@@ -268,6 +310,15 @@ function DefaultEnv.init(): tealdoc.Env
         end
     }
 
+    local markdown_function_signature_phase: Generator.Phase = {
+        name = "markdown_function_signature",
+        run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
+            assert(item is tealdoc.FunctionItem)
+            markdown_section(ctx, item, "Synopsis")
+            function_signature_phase.run(ctx, item)
+        end
+    }
+
     local variable_signature_phase: Generator.Phase = {
         name = "variable_signature",
         run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
@@ -280,6 +331,14 @@ function DefaultEnv.init(): tealdoc.Env
         end
     }
 
+    local markdown_variable_signature_phase: Generator.Phase = {
+        name = "markdown_variable_signature",
+        run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
+            markdown_section(ctx, item, "Synopsis")
+            variable_signature_phase.run(ctx, item)
+        end
+    }
+
     local type_signature_phase: Generator.Phase = {
         name = "type_signature",
         run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
@@ -289,6 +348,14 @@ function DefaultEnv.init(): tealdoc.Env
                 signatures.for_type(ctx, item)
                 ctx.builder:line()
             end)
+        end
+    }
+
+    local markdown_type_signature_phase: Generator.Phase = {
+        name = "markdown_type_signature",
+        run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
+            markdown_section(ctx, item, "Synopsis")
+            type_signature_phase.run(ctx, item)
         end
     }
 
@@ -352,6 +419,37 @@ function DefaultEnv.init(): tealdoc.Env
         end
     }
 
+    local markdown_function_params_phase: Generator.Phase = {
+        name = "markdown_function_params",
+        run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
+            assert(item is tealdoc.FunctionItem)
+            markdown_section(ctx, item, "Arguments")
+
+            if not item.params or #item.params == 0 then
+                ctx.builder:paragraph("None.")
+                return
+            end
+
+            ctx.builder:unordered_list(function(list_item: function(content: function))
+                for _, param in ipairs(item.params) do
+                    list_item(function()
+                        if param.name then
+                            ctx.builder:b(function()
+                                ctx.builder:code(attr("name"), param.name)
+                            end)
+                        end
+                        ctx.builder:text(attr("type"), " (", function() ctx.builder:code(param.type or "?") end, ")")
+                        if param.description then
+                            ctx.builder:text(attr("description"), " — ", function()
+                                ctx.builder:md(param.description)
+                            end)
+                        end
+                    end)
+                end
+            end)
+        end
+    }
+
     local function_returns_phase: Generator.Phase = {
         name = "function_returns",
         run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
@@ -376,10 +474,50 @@ function DefaultEnv.init(): tealdoc.Env
         end
     }
 
+    local markdown_function_returns_phase: Generator.Phase = {
+        name = "markdown_function_returns",
+        run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
+            assert(item is tealdoc.FunctionItem)
+            markdown_section(ctx, item, "Returns")
+
+            if not item.returns or #item.returns == 0 then
+                ctx.builder:paragraph("None.")
+                return
+            end
+
+            ctx.builder:ordered_list(function(list_item: function(content: function))
+                for _, ret in ipairs(item.returns) do
+                    list_item(function()
+                        ctx.builder:text(attr("type"), "(", function() ctx.builder:code(ret.type or "?") end, ")")
+                        if ret.description then
+                            ctx.builder:text(attr("description"), " — ", function() ctx.builder:md(ret.description) end)
+                        end
+                    end)
+                end
+            end)
+        end
+    }
+
     MarkdownGenerator.item_phases["module"] = {module_header_phase}
-    MarkdownGenerator.item_phases["function"] = {header_phase, function_signature_phase, text_phase, type_params_phase, function_params_phase, function_returns_phase}
-    MarkdownGenerator.item_phases["variable"] = {header_phase, variable_signature_phase, text_phase}
-    MarkdownGenerator.item_phases["type"] = {header_phase, type_signature_phase, text_phase, type_params_phase}
+    MarkdownGenerator.item_phases["function"] = {
+        markdown_header_phase,
+        text_phase,
+        markdown_function_signature_phase,
+        type_params_phase,
+        markdown_function_params_phase,
+        markdown_function_returns_phase
+    }
+    MarkdownGenerator.item_phases["variable"] = {
+        markdown_header_phase,
+        text_phase,
+        markdown_variable_signature_phase
+    }
+    MarkdownGenerator.item_phases["type"] = {
+        markdown_header_phase,
+        text_phase,
+        markdown_type_signature_phase,
+        type_params_phase
+    }
     MarkdownGenerator.item_phases["enumvalue"] = {header_phase, text_phase}
     MarkdownGenerator.item_phases["markdown"] = {text_phase}
 

--- a/src/tealdoc/default_env.tl
+++ b/src/tealdoc/default_env.tl
@@ -265,27 +265,76 @@ function DefaultEnv.init(): tealdoc.Env
         return nil
     end
 
+    local function markdown_item_level(ctx: Generator.Phase.Context, item: tealdoc.Item): integer
+        local level = 2
+        local current = item
+        while current.parent do
+            local parent = ctx.env.registry[current.parent]
+            if not parent or parent.kind == "module" or parent.path == ctx.module_name then
+                break
+            end
+            level = math.min(level + 1, 5)
+            current = parent
+        end
+        return level
+    end
+
+    local function markdown_heading(
+        ctx: Generator.Phase.Context,
+        level: integer,
+        attribute: Generator.Attribute,
+        title: string
+    )
+        if level == 2 then
+            ctx.builder:h2(attribute, title)
+        elseif level == 3 then
+            ctx.builder:h3(attribute, title)
+        elseif level == 4 then
+            ctx.builder:h4(attribute, title)
+        elseif level == 5 then
+            ctx.builder:h5(attribute, title)
+        else
+            ctx.builder:h6(attribute, title)
+        end
+    end
+
     local markdown_header_phase: Generator.Phase = {
         name = "markdown_header",
         run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
             local parent = overload_parent(ctx, item)
             if parent then
                 if parent.children and parent.children[1] == item.path then
-                    ctx.builder:h2(attr("path"), display_path(ctx, parent))
+                    markdown_heading(
+                        ctx,
+                        markdown_item_level(ctx, parent),
+                        attr("path"),
+                        display_path(ctx, parent)
+                    )
                 end
-                ctx.builder:h3(attr("header"), "Function")
+                markdown_heading(
+                    ctx,
+                    markdown_item_level(ctx, item),
+                    attr("header"),
+                    "Function"
+                )
             else
-                ctx.builder:h2(attr("path"), display_path(ctx, item))
+                markdown_heading(
+                    ctx,
+                    markdown_item_level(ctx, item),
+                    attr("path"),
+                    display_path(ctx, item)
+                )
             end
         end
     }
 
     local function markdown_section(ctx: Generator.Phase.Context, item: tealdoc.Item, title: string)
-        if overload_parent(ctx, item) then
-            ctx.builder:h4(attr("header"), title)
-        else
-            ctx.builder:h3(attr("header"), title)
-        end
+        markdown_heading(
+            ctx,
+            markdown_item_level(ctx, item) + 1,
+            attr("header"),
+            title
+        )
     end
 
     local text_phase: Generator.Phase = {
@@ -310,15 +359,6 @@ function DefaultEnv.init(): tealdoc.Env
         end
     }
 
-    local markdown_function_signature_phase: Generator.Phase = {
-        name = "markdown_function_signature",
-        run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
-            assert(item is tealdoc.FunctionItem)
-            markdown_section(ctx, item, "Synopsis")
-            function_signature_phase.run(ctx, item)
-        end
-    }
-
     local variable_signature_phase: Generator.Phase = {
         name = "variable_signature",
         run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
@@ -331,14 +371,6 @@ function DefaultEnv.init(): tealdoc.Env
         end
     }
 
-    local markdown_variable_signature_phase: Generator.Phase = {
-        name = "markdown_variable_signature",
-        run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
-            markdown_section(ctx, item, "Synopsis")
-            variable_signature_phase.run(ctx, item)
-        end
-    }
-
     local type_signature_phase: Generator.Phase = {
         name = "type_signature",
         run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
@@ -348,14 +380,6 @@ function DefaultEnv.init(): tealdoc.Env
                 signatures.for_type(ctx, item)
                 ctx.builder:line()
             end)
-        end
-    }
-
-    local markdown_type_signature_phase: Generator.Phase = {
-        name = "markdown_type_signature",
-        run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
-            markdown_section(ctx, item, "Synopsis")
-            type_signature_phase.run(ctx, item)
         end
     }
 
@@ -382,6 +406,40 @@ function DefaultEnv.init(): tealdoc.Env
 
                         if typearg.description then
                             ctx.builder:text(attr("description"), " — ", function() ctx.builder:md(typearg.description) end)
+                        end
+                    end)
+                end
+            end)
+        end
+    }
+
+    local markdown_type_params_phase: Generator.Phase = {
+        name = "markdown_type_params",
+        run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
+            assert(item is tealdoc.TypeItem or item is tealdoc.FunctionItem)
+
+            if not item.typeargs or #item.typeargs == 0 then
+                return
+            end
+
+            markdown_section(ctx, item, "Type Parameters")
+            ctx.builder:unordered_list(function(list_item: function(content: function))
+                for _, typearg in ipairs(item.typeargs) do
+                    list_item(function()
+                        ctx.builder:b(function()
+                            ctx.builder:code(attr("name"), typearg.name or "?")
+                        end)
+
+                        if typearg.constraint then
+                            ctx.builder:text(attr("constraint"), " ( is ", function()
+                                ctx.builder:code(typearg.constraint)
+                            end, ")")
+                        end
+
+                        if typearg.description then
+                            ctx.builder:text(attr("description"), " — ", function()
+                                ctx.builder:md(typearg.description)
+                            end)
                         end
                     end)
                 end
@@ -502,23 +560,23 @@ function DefaultEnv.init(): tealdoc.Env
     MarkdownGenerator.item_phases["function"] = {
         markdown_header_phase,
         text_phase,
-        markdown_function_signature_phase,
-        type_params_phase,
+        function_signature_phase,
+        markdown_type_params_phase,
         markdown_function_params_phase,
         markdown_function_returns_phase
     }
     MarkdownGenerator.item_phases["variable"] = {
         markdown_header_phase,
         text_phase,
-        markdown_variable_signature_phase
+        variable_signature_phase
     }
     MarkdownGenerator.item_phases["type"] = {
         markdown_header_phase,
         text_phase,
-        markdown_type_signature_phase,
-        type_params_phase
+        type_signature_phase,
+        markdown_type_params_phase
     }
-    MarkdownGenerator.item_phases["enumvalue"] = {header_phase, text_phase}
+    MarkdownGenerator.item_phases["enumvalue"] = {markdown_header_phase, text_phase}
     MarkdownGenerator.item_phases["markdown"] = {text_phase}
 
     HTMLGenerator.item_phases["module"] = {module_header_phase, detailed_signature_phase}

--- a/src/tealdoc/generator/markdown.tl
+++ b/src/tealdoc/generator/markdown.tl
@@ -4,13 +4,13 @@ local log = require("tealdoc.log")
 
 local record MarkdownBuilder is Generator.Builder
     output: {string}
-    in_code_block: boolean
+    in_code: boolean
 end
 
 function MarkdownBuilder.init(): MarkdownBuilder
     local builder: MarkdownBuilder = {
         output = {},
-        in_code_block = false
+        in_code = false
     }
 
     local self = setmetatable(builder, {__index = MarkdownBuilder})
@@ -68,7 +68,7 @@ MarkdownBuilder.line = function(self, ...: Content): MarkdownBuilder
 end
 
 MarkdownBuilder.link = function(self, to: string, ...: Content): MarkdownBuilder
-    if self.in_code_block then
+    if self.in_code then
         self:text(...)
         return self
     end
@@ -79,7 +79,7 @@ MarkdownBuilder.link = function(self, to: string, ...: Content): MarkdownBuilder
 end
 
 MarkdownBuilder.link_url = function(self, url: string, ...: Content): MarkdownBuilder
-    if self.in_code_block then
+    if self.in_code then
         self:text(...)
         return self
     end
@@ -93,7 +93,7 @@ MarkdownBuilder.text = function(self, ...: Content): MarkdownBuilder
     for i = 1, select("#", ...) do
         local c = select(i, ...)
         if c is string then
-            table.insert(self.output, self.in_code_block and c or escape_html(c))
+            table.insert(self.output, self.in_code and c or escape_html(c))
         elseif c is function then
             c(self)
         end
@@ -124,15 +124,18 @@ MarkdownBuilder.paragraph = function(self, ...: Content): MarkdownBuilder
     self:line()
     self:text(...)
     self:line()
+    self:line()
     return self
 end
 
 MarkdownBuilder.code_block = function(self, content: function): MarkdownBuilder
+    self:line()
     self:rawline("```teal")
-    self.in_code_block = true
+    self.in_code = true
     content()
-    self.in_code_block = false
+    self.in_code = false
     self:rawline("```")
+    self:line()
     return self
 end
 MarkdownBuilder.ordered_list = function(self, content: function(item: function(content: function))): MarkdownBuilder
@@ -176,7 +179,10 @@ MarkdownBuilder.i = function(self, ...: Content): MarkdownBuilder
 end
 MarkdownBuilder.code = function(self, ...: Content): MarkdownBuilder
     self:rawtext("`")
+    local was_in_code = self.in_code
+    self.in_code = true
     self:text(...)
+    self.in_code = was_in_code
     self:rawtext("`")
     return self
 end

--- a/src/tealdoc/generator/markdown.tl
+++ b/src/tealdoc/generator/markdown.tl
@@ -4,11 +4,13 @@ local log = require("tealdoc.log")
 
 local record MarkdownBuilder is Generator.Builder
     output: {string}
+    in_code_block: boolean
 end
 
 function MarkdownBuilder.init(): MarkdownBuilder
     local builder: MarkdownBuilder = {
-        output = {}
+        output = {},
+        in_code_block = false
     }
 
     local self = setmetatable(builder, {__index = MarkdownBuilder})
@@ -66,6 +68,10 @@ MarkdownBuilder.line = function(self, ...: Content): MarkdownBuilder
 end
 
 MarkdownBuilder.link = function(self, to: string, ...: Content): MarkdownBuilder
+    if self.in_code_block then
+        self:text(...)
+        return self
+    end
     self:rawtext("<a href=\"#", escape_html(to), "\">")
     self:text(...)
     self:rawtext("</a>")
@@ -73,6 +79,10 @@ MarkdownBuilder.link = function(self, to: string, ...: Content): MarkdownBuilder
 end
 
 MarkdownBuilder.link_url = function(self, url: string, ...: Content): MarkdownBuilder
+    if self.in_code_block then
+        self:text(...)
+        return self
+    end
     self:rawtext("<a href=\"", escape_html(url), "\">")
     self:text(...)
     self:rawtext("</a>")
@@ -83,7 +93,7 @@ MarkdownBuilder.text = function(self, ...: Content): MarkdownBuilder
     for i = 1, select("#", ...) do
         local c = select(i, ...)
         if c is string then
-            table.insert(self.output, escape_html(c))
+            table.insert(self.output, self.in_code_block and c or escape_html(c))
         elseif c is function then
             c(self)
         end
@@ -118,9 +128,11 @@ MarkdownBuilder.paragraph = function(self, ...: Content): MarkdownBuilder
 end
 
 MarkdownBuilder.code_block = function(self, content: function): MarkdownBuilder
-    self:rawtext("<pre><code>")
+    self:rawline("```teal")
+    self.in_code_block = true
     content()
-    self:rawline("</code></pre>")
+    self.in_code_block = false
+    self:rawline("```")
     return self
 end
 MarkdownBuilder.ordered_list = function(self, content: function(item: function(content: function))): MarkdownBuilder


### PR DESCRIPTION
Depends on #21.

Put prose from source docblocks before a Synopsis section, then render explicit Arguments and Returns sections. Empty sections say `None.`, matching API-reference pages instead of omitting the shape.

Inline and fenced Teal remain raw source text, so generic syntax is not emitted as HTML entities.

Validated with:

- `make build`
- `busted -m "build/?.lua;build/?/init.lua" spec/generator`
- `make check-generated-diff BASE_REF=3a39028`