### PR TITLE
Fix site theme layout, tabulate parameters, and publish our own docs

### DIFF
--- a/build/tealdoc/default_env.lua
+++ b/build/tealdoc/default_env.lua
@@ -586,6 +586,16 @@ function DefaultEnv.init()
       end,
    }
 
+
+
+
+
+
+
+   local type_param_columns = { "Name", "Constraint", "Description" }
+   local param_columns = { "Name", "Type", "Description" }
+   local return_columns = { "Type", "Description" }
+
    local type_params_phase = {
       name = "type_params",
       run = function(ctx, item)
@@ -596,19 +606,23 @@ function DefaultEnv.init()
          end
 
          ctx.builder:h4(attr("header"), "Type Parameters")
-         ctx.builder:unordered_list(function(list_item)
+         ctx.builder:table(type_param_columns, function(row)
             for _, typearg in ipairs(item.typeargs) do
-               list_item(function()
-                  ctx.builder:b(function()
-                     ctx.builder:code(attr("name"), typearg.name or "?")
-                  end)
-
+               row(
+               function()
+                  ctx.builder:code(attr("name"), typearg.name or "?")
+               end,
+               function()
                   if typearg.constraint then
-                     ctx.builder:text(attr("constraint"), " ( is ", function() ctx.builder:code(typearg.constraint) end, ")")
-                  end
+                     ctx.builder:code(
+                     attr("constraint"),
+                     typearg.constraint)
 
+                  end
+               end,
+               function()
                   if typearg.description then
-                     ctx.builder:text(attr("description"), " — ", function()
+                     ctx.builder:text(attr("description"), function()
                         ctx.builder:md(markdown_with_type_links(
                         ctx,
                         typearg.description))
@@ -616,6 +630,7 @@ function DefaultEnv.init()
                      end)
                   end
                end)
+
             end
          end)
       end,
@@ -631,21 +646,23 @@ function DefaultEnv.init()
          end
 
          markdown_section(ctx, item, "Type Parameters")
-         ctx.builder:unordered_list(function(list_item)
+         ctx.builder:table(type_param_columns, function(row)
             for _, typearg in ipairs(item.typeargs) do
-               list_item(function()
-                  ctx.builder:b(function()
-                     ctx.builder:code(attr("name"), typearg.name or "?")
-                  end)
-
+               row(
+               function()
+                  ctx.builder:code(attr("name"), typearg.name or "?")
+               end,
+               function()
                   if typearg.constraint then
-                     ctx.builder:text(attr("constraint"), " ( is ", function()
-                        ctx.builder:code(typearg.constraint)
-                     end, ")")
-                  end
+                     ctx.builder:code(
+                     attr("constraint"),
+                     typearg.constraint)
 
+                  end
+               end,
+               function()
                   if typearg.description then
-                     ctx.builder:text(attr("description"), " — ", function()
+                     ctx.builder:text(attr("description"), function()
                         ctx.builder:md(markdown_with_type_links(
                         ctx,
                         typearg.description))
@@ -653,6 +670,7 @@ function DefaultEnv.init()
                      end)
                   end
                end)
+
             end
          end)
       end,
@@ -668,17 +686,20 @@ function DefaultEnv.init()
          end
 
          ctx.builder:h4(attr("name"), "Parameters")
-         ctx.builder:unordered_list(function(list_item)
+         ctx.builder:table(param_columns, function(row)
             for _, param in ipairs(item.params) do
-               list_item(function()
+               row(
+               function()
                   if param.name then
-                     ctx.builder:b(function()
-                        ctx.builder:code(attr("name"), param.name)
-                     end)
+                     ctx.builder:code(attr("name"), param.name)
                   end
-                  ctx.builder:text(attr("type"), " (", function() ctx.builder:code(param.type or "?") end, ")")
+               end,
+               function()
+                  ctx.builder:code(attr("type"), param.type or "?")
+               end,
+               function()
                   if param.description then
-                     ctx.builder:text(attr("description"), " — ", function()
+                     ctx.builder:text(attr("description"), function()
                         ctx.builder:md(markdown_with_type_links(
                         ctx,
                         param.description))
@@ -686,6 +707,7 @@ function DefaultEnv.init()
                      end)
                   end
                end)
+
             end
          end)
       end,
@@ -702,19 +724,26 @@ function DefaultEnv.init()
             return
          end
 
-         ctx.builder:unordered_list(function(list_item)
+         ctx.builder:table(param_columns, function(row)
             for _, param in ipairs(item.params) do
-               list_item(function()
+               row(
+               function()
                   if param.name then
-                     ctx.builder:b(function()
-                        ctx.builder:code(attr("name"), param.name)
-                     end)
+                     ctx.builder:code(attr("name"), param.name)
                   end
-                  ctx.builder:text(attr("type"), " (", function()
-                     markdown_type(ctx, param.type or "?", param.type_references)
-                  end, ")")
+               end,
+               function()
+                  ctx.builder:text(attr("type"), function()
+                     markdown_type(
+                     ctx,
+                     param.type or "?",
+                     param.type_references)
+
+                  end)
+               end,
+               function()
                   if param.description then
-                     ctx.builder:text(attr("description"), " — ", function()
+                     ctx.builder:text(attr("description"), function()
                         ctx.builder:md(markdown_with_type_links(
                         ctx,
                         param.description))
@@ -722,6 +751,7 @@ function DefaultEnv.init()
                      end)
                   end
                end)
+
             end
          end)
       end,
@@ -738,12 +768,15 @@ function DefaultEnv.init()
 
          ctx.builder:h4(attr("header"), "Returns")
 
-         ctx.builder:ordered_list(function(list_item)
+         ctx.builder:table(return_columns, function(row)
             for _, ret in ipairs(item.returns) do
-               list_item(function()
-                  ctx.builder:text(attr("type"), "(", function() ctx.builder:code(ret.type or "?") end, ")")
+               row(
+               function()
+                  ctx.builder:code(attr("type"), ret.type or "?")
+               end,
+               function()
                   if ret.description then
-                     ctx.builder:text(attr("description"), " — ", function()
+                     ctx.builder:text(attr("description"), function()
                         ctx.builder:md(markdown_with_type_links(
                         ctx,
                         ret.description))
@@ -751,6 +784,7 @@ function DefaultEnv.init()
                      end)
                   end
                end)
+
             end
          end)
       end,
@@ -767,14 +801,21 @@ function DefaultEnv.init()
             return
          end
 
-         ctx.builder:ordered_list(function(list_item)
+         ctx.builder:table(return_columns, function(row)
             for _, ret in ipairs(item.returns) do
-               list_item(function()
-                  ctx.builder:text(attr("type"), "(", function()
-                     markdown_type(ctx, ret.type or "?", ret.type_references)
-                  end, ")")
+               row(
+               function()
+                  ctx.builder:text(attr("type"), function()
+                     markdown_type(
+                     ctx,
+                     ret.type or "?",
+                     ret.type_references)
+
+                  end)
+               end,
+               function()
                   if ret.description then
-                     ctx.builder:text(attr("description"), " — ", function()
+                     ctx.builder:text(attr("description"), function()
                         ctx.builder:md(markdown_with_type_links(
                         ctx,
                         ret.description))
@@ -782,6 +823,7 @@ function DefaultEnv.init()
                      end)
                   end
                end)
+
             end
          end)
       end,

--- a/build/tealdoc/generator.lua
+++ b/build/tealdoc/generator.lua
@@ -85,6 +85,12 @@ local Generator = { Attribute = {}, Base = {} }
 
 
 
+
+
+
+
+
+
 Generator.attr = function(name)
    return { name = name }
 end

--- a/build/tealdoc/generator/html/builder.lua
+++ b/build/tealdoc/generator/html/builder.lua
@@ -1,4 +1,4 @@
-local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local table = _tl_compat and _tl_compat.table or table; local type = type; local Generator = require("tealdoc.generator")
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local table = _tl_compat and _tl_compat.table or table; local type = type; local Generator = require("tealdoc.generator")
 local Text = require("tealdoc.generator.text")
 
 local lunamark = require("lunamark")
@@ -186,6 +186,33 @@ HTMLBuilder.unordered_list = function(self, content)
    self:rawline("<ul>")
    content(item)
    self:rawline("</ul>")
+   return self
+end
+
+HTMLBuilder.table = function(self, headers, content)
+   local row = function(...)
+      self:rawtext("<tr>")
+      for i = 1, select("#", ...) do
+         self:rawtext("<td>")
+         local write = (select(i, ...))
+         write()
+         self:rawtext("</td>")
+      end
+      self:rawline("</tr>")
+   end
+
+   self:rawline("<table>")
+   self:rawtext("<thead><tr>")
+   for _, header in ipairs(headers) do
+      self:rawtext("<th>")
+      self:text(header)
+      self:rawtext("</th>")
+   end
+   self:rawline("</tr></thead>")
+   self:rawline("<tbody>")
+   content(row)
+   self:rawline("</tbody>")
+   self:rawline("</table>")
    return self
 end
 

--- a/build/tealdoc/generator/html/default_css.lua
+++ b/build/tealdoc/generator/html/default_css.lua
@@ -29,6 +29,31 @@ return [[
     li {
         margin: 0.5em 0;
     }
+    table {
+        border-collapse: collapse;
+        margin: 0.5em 0 1.5em 0;
+        width: 100%;
+        display: block;
+        overflow-x: auto;
+    }
+    th, td {
+        border-bottom: 1px solid #e2e2e2;
+        padding: 0.4em 0.8em 0.4em 0;
+        text-align: left;
+        vertical-align: top;
+    }
+    th {
+        color: #555;
+        font-size: 0.85em;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
+    /* Every column but the last names a type or a parameter, so it should stay
+       on one line and let the description take the rest of the width. */
+    td:not(:last-child) {
+        white-space: nowrap;
+    }
     a {
         color: #007bff;
         text-decoration: none;

--- a/build/tealdoc/generator/markdown.lua
+++ b/build/tealdoc/generator/markdown.lua
@@ -155,6 +155,59 @@ MarkdownBuilder.unordered_list = function(self, content)
    return self
 end
 
+
+
+
+MarkdownBuilder.table = function(self, headers, content)
+
+
+
+
+
+
+
+   local function cell(write)
+      local outer = self.output
+      self.output = {}
+      write()
+      local written = table.concat(self.output, "")
+      self.output = outer
+
+      written = written:gsub("`([^`]*)`", function(inner)
+         if not inner:find("|", 1, true) then
+            return "`" .. inner .. "`"
+         end
+         return "<code>" ..
+         (Text.escape_html(inner):gsub("|", "&#124;")) ..
+         "</code>"
+      end)
+
+
+
+      return (written:gsub("|", "&#124;"):gsub("%s*\n%s*", " "))
+   end
+
+   local row = function(...)
+      local cells = {}
+      for i = 1, select("#", ...) do
+         table.insert(cells, cell((select(i, ...))))
+      end
+      self:rawline("| ", table.concat(cells, " | "), " |")
+   end
+
+   local rule = {}
+   for _ = 1, #headers do
+      table.insert(rule, "---")
+   end
+
+   self:line()
+   self:rawline("| ", table.concat(headers, " | "), " |")
+   self:rawline("| ", table.concat(rule, " | "), " |")
+   content(row)
+   self:line()
+   return self
+end
+
 MarkdownBuilder.b = function(self, ...)
    self:rawtext("**")
    self:text(...)

--- a/build/tealdoc/generator/site.lua
+++ b/build/tealdoc/generator/site.lua
@@ -61,23 +61,40 @@ local function read_file(path)
    return contents
 end
 
-local function append_custom_css(css, custom)
-   local imports = {}
-   while true do
-      local first, last, statement = custom:find(
-      "^%s*(@import%s+[^;]+;)")
 
-      if not first then
-         break
+
+
+
+
+
+local function append_custom_css(css, custom)
+   local preamble = {}
+   local imports = {}
+   local body = custom
+   while true do
+      local remainder = body:gsub("^%s+", "")
+      local comment = remainder:match("^(/%*.-%*/)")
+      if comment then
+         table.insert(preamble, comment)
+         body = remainder:sub(#comment + 1)
+      else
+         local first, last, statement = remainder:find("^(@import%s+[^;]+;)")
+         if not first then
+            break
+         end
+         table.insert(imports, statement)
+         body = remainder:sub(last + 1)
       end
-      table.insert(imports, statement)
-      custom = custom:sub(last + 1)
    end
-   local prefix = ""
-   if #imports > 0 then
-      prefix = table.concat(imports, "\n") .. "\n\n"
+   if #imports == 0 then
+      return css .. "\n" .. custom:gsub("^%s+", "")
    end
-   return prefix .. css .. "\n" .. custom:gsub("^%s+", "")
+   local prefix = table.concat(preamble, "\n\n")
+   if prefix ~= "" then
+      prefix = prefix .. "\n\n"
+   end
+   prefix = prefix .. table.concat(imports, "\n") .. "\n\n"
+   return prefix .. css .. "\n" .. body:gsub("^%s+", "")
 end
 
 local function write_file(path, contents)
@@ -749,14 +766,21 @@ local function headings(html)
          local outline_title = title
          if level == 2 then
             outline_prefix = ""
-         elseif outline_prefix ~= "" and
-            title:sub(1, #outline_prefix + 1) ==
-            outline_prefix .. "." then
-
-            outline_title = "↳ " ..
-            title:sub(#outline_prefix + 2)
          else
-            outline_prefix = title:match("^(.*)%.") or ""
+
+
+
+
+
+            if outline_prefix == "" then
+               outline_prefix = title:match("^(.*)%.") or ""
+            end
+            if outline_prefix ~= "" and
+               title:sub(1, #outline_prefix + 1) ==
+               outline_prefix .. "." then
+
+               outline_title = title:sub(#outline_prefix + 2)
+            end
          end
          table.insert(found, {
             id = id,

--- a/build/tealdoc/generator/site/css/base.lua
+++ b/build/tealdoc/generator/site/css/base.lua
@@ -61,8 +61,8 @@ input {
     min-height: var(--tealdoc-header-height);
     margin: 0;
     padding: 0;
-    border-bottom: 1px solid var(--tealdoc-border);
-    background: color-mix(in srgb, var(--tealdoc-background) 92%, transparent);
+    border-bottom: 1px solid var(--tealdoc-header-border);
+    background: var(--tealdoc-header-background);
     backdrop-filter: blur(12px);
 }
 
@@ -82,7 +82,7 @@ input {
     flex: none;
     align-items: center;
     gap: 0.6rem;
-    color: var(--tealdoc-text);
+    color: var(--tealdoc-header-color);
     font-size: 1rem;
     font-weight: 650;
     letter-spacing: -0.01em;
@@ -108,7 +108,7 @@ input {
 .tealdoc-top-nav a {
     position: relative;
     padding: 0.45rem 0.65rem;
-    color: var(--tealdoc-text-muted);
+    color: var(--tealdoc-header-muted-color);
     border-radius: 7px;
     font-size: 0.875rem;
     font-weight: 500;
@@ -116,8 +116,8 @@ input {
 }
 
 .tealdoc-top-nav a:hover {
-    color: var(--tealdoc-text);
-    background: var(--tealdoc-background-alt);
+    color: var(--tealdoc-header-color);
+    background: var(--tealdoc-header-control-background);
 }
 
 .tealdoc-top-nav a[aria-current="page"] {
@@ -145,18 +145,18 @@ input {
     gap: 0.45rem;
     margin: 0 0 0 1.75rem;
     padding: 0.35rem 0.65rem;
-    color: var(--tealdoc-text-muted);
-    border: 1px solid var(--tealdoc-border);
+    color: var(--tealdoc-header-muted-color);
+    border: 1px solid var(--tealdoc-header-border);
     border-radius: 8px;
-    background: var(--tealdoc-background-alt);
+    background: var(--tealdoc-header-control-background);
     box-shadow: none;
     font-size: 0.82rem;
 }
 
 .tealdoc-search-button:hover {
-    color: var(--tealdoc-text);
-    border-color: var(--tealdoc-text-faint);
-    background: var(--tealdoc-background-alt);
+    color: var(--tealdoc-header-color);
+    border-color: var(--tealdoc-header-muted-color);
+    background: var(--tealdoc-header-control-background);
 }
 
 .tealdoc-icon-link {
@@ -168,15 +168,15 @@ input {
     justify-content: center;
     margin: 0;
     padding: 0;
-    color: var(--tealdoc-text-muted);
+    color: var(--tealdoc-header-muted-color);
     border-radius: 7px;
     cursor: pointer;
     text-decoration: none;
 }
 
 .tealdoc-icon-link:hover {
-    color: var(--tealdoc-text);
-    background: var(--tealdoc-background-alt);
+    color: var(--tealdoc-header-color);
+    background: var(--tealdoc-header-control-background);
 }
 
 .tealdoc-theme-input:focus-visible ~ .tealdoc-site .tealdoc-theme-toggle {
@@ -222,10 +222,10 @@ input {
 .tealdoc-search-button kbd {
     margin-left: auto;
     padding: 0.1rem 0.35rem;
-    color: var(--tealdoc-text-faint);
-    border: 1px solid var(--tealdoc-border);
+    color: var(--tealdoc-header-muted-color);
+    border: 1px solid var(--tealdoc-header-border);
     border-radius: 4px;
-    background: var(--tealdoc-background);
+    background: transparent;
     box-shadow: none;
     font-size: 0.68rem;
 }

--- a/build/tealdoc/generator/site/css/components.lua
+++ b/build/tealdoc/generator/site/css/components.lua
@@ -65,10 +65,17 @@ return [[
     margin-bottom: 0;
 }
 
+/* Pico lays a [role="group"] out as an inline flex row, which is right for a
+ * button group and wrong for a stack of labelled code blocks, so the display
+ * is stated here rather than left to the classless sheet. */
 .tealdoc-code-group {
+    display: block;
+    overflow: hidden;
     margin: 1.25rem 0;
     border: 1px solid var(--tealdoc-border);
+    border-radius: var(--tealdoc-code-block-radius);
     background: var(--tealdoc-code-background);
+    box-shadow: none;
 }
 
 .tealdoc-labeled-code {
@@ -96,6 +103,11 @@ return [[
     border-right: 0;
     border-bottom: 0;
     border-left: 0;
+}
+
+.tealdoc-code-group > .tealdoc-labeled-code pre {
+    border: 0;
+    border-radius: 0;
 }
 
 .tealdoc-page-nav {

--- a/build/tealdoc/generator/site/css/content.lua
+++ b/build/tealdoc/generator/site/css/content.lua
@@ -291,4 +291,26 @@ return [[
     width: 100%;
 }
 
+.tealdoc-content th,
+.tealdoc-content td {
+    padding: 0.4em 0.9em 0.4em 0;
+    vertical-align: top;
+}
+
+.tealdoc-content thead th {
+    color: var(--tealdoc-text-muted);
+    font-size: 0.82em;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+/* A parameter row is as tall as its description, and the name and the type it
+   belongs to have to stay beside the first line of that description rather
+   than float in the middle of it. Every column but the last holds one of those
+   short values, so it keeps to one line and lets the description take the
+   width that is left. */
+.tealdoc-content td:not(:last-child) {
+    white-space: nowrap;
+}
+
 ]]

--- a/build/tealdoc/generator/site/css/content.lua
+++ b/build/tealdoc/generator/site/css/content.lua
@@ -10,7 +10,7 @@ return [[
     border-radius: 0;
 }
 
-.tealdoc-content:not(.tealdoc-home-content) {
+.tealdoc-content {
     font-size: var(--tealdoc-content-font-size);
 }
 
@@ -163,12 +163,18 @@ return [[
 
 .tealdoc-content pre {
     overflow: auto;
-    padding: 0.5rem 0.6rem;
+    padding: var(--tealdoc-code-block-padding);
     border: 1px solid var(--tealdoc-border);
     border-radius: var(--tealdoc-code-block-radius);
     background: var(--tealdoc-code-background);
     font-family: var(--tealdoc-font-mono);
     line-height: 1.55;
+}
+
+/* The block's padding is the pre's, once. Pico pads the inner code as well,
+ * which doubles it and leaves the two halves impossible to tune apart. */
+.tealdoc-content pre > code {
+    padding: 0;
 }
 
 .tealdoc-content code[class*="language-"] {
@@ -180,22 +186,18 @@ return [[
 }
 
 .tealdoc-content :not(pre) > code {
-    padding: 0;
-    background: transparent;
+    padding: var(--tealdoc-inline-code-padding);
+    border-radius: var(--tealdoc-inline-code-radius);
+    background: var(--tealdoc-inline-code-background);
     font-size: var(--tealdoc-inline-code-font-size);
     font-weight: 550;
 }
 
-.tealdoc-content
-    :not(pre)
-    > code.tealdoc-inline-code-before {
-    padding-inline-start: var(--tealdoc-inline-code-padding);
-}
-
-.tealdoc-content
-    :not(pre)
-    > code.tealdoc-inline-code-after {
-    padding-inline-end: var(--tealdoc-inline-code-padding);
+.tealdoc-content :is(h1, h2, h3, h4, h5, h6) code {
+    padding: 0;
+    background: transparent;
+    font-size: 1em;
+    font-weight: inherit;
 }
 
 .tealdoc-content a > code {

--- a/build/tealdoc/generator/site/css/home.lua
+++ b/build/tealdoc/generator/site/css/home.lua
@@ -24,7 +24,7 @@ return [[
     max-width: 720px;
     margin: 0;
     color: var(--tealdoc-accent);
-    font-size: clamp(3rem, 7vw, 5.5rem);
+    font-size: var(--tealdoc-hero-name-size);
     letter-spacing: -0.04em;
     line-height: 0.95;
 }
@@ -33,7 +33,7 @@ return [[
     max-width: 650px;
     margin: 1.5rem 0 0;
     color: var(--tealdoc-text-muted);
-    font-size: clamp(1.3rem, 2.5vw, 2rem);
+    font-size: var(--tealdoc-hero-text-size);
     line-height: 1.35;
 }
 

--- a/build/tealdoc/generator/site/css/navigation.lua
+++ b/build/tealdoc/generator/site/css/navigation.lua
@@ -23,13 +23,14 @@ return [[
 .tealdoc-sidebar {
     padding: 1.25rem 1rem 2rem;
     border-right: 1px solid var(--tealdoc-border);
-    background: var(--tealdoc-background-alt);
-    box-shadow: -100vw 0 0 100vw var(--tealdoc-background-alt);
+    background: var(--tealdoc-sidebar-background);
+    box-shadow: -100vw 0 0 100vw var(--tealdoc-sidebar-background);
 }
 
 .tealdoc-outline-title {
     margin: 0 0 0.75rem;
     color: var(--tealdoc-text-muted);
+    font-family: var(--tealdoc-outline-font-family);
     font-size: 0.66rem;
     font-weight: 600;
 }
@@ -51,6 +52,7 @@ return [[
     padding: var(--tealdoc-sidebar-item-padding);
     color: var(--tealdoc-sidebar-item-color);
     border-radius: 6px;
+    font-family: var(--tealdoc-sidebar-font-family);
     font-size: var(--tealdoc-sidebar-font-size);
     font-weight: var(--tealdoc-sidebar-font-weight);
     line-height: 1.3;
@@ -65,13 +67,21 @@ return [[
 .tealdoc-sidebar a[aria-current="page"] {
     color: var(--tealdoc-accent);
     background: transparent;
-    font-weight: var(--tealdoc-sidebar-font-weight);
+    font-weight: var(--tealdoc-sidebar-active-font-weight);
 }
 
 .tealdoc-sidebar li.tealdoc-sidebar-section {
     margin-top: var(--tealdoc-sidebar-section-gap) !important;
     padding-top: var(--tealdoc-sidebar-section-padding);
     border-top: 1px solid var(--tealdoc-sidebar-section-border);
+}
+
+/* The first section opens the sidebar, so it carries neither the rule that
+ * separates one group from the last nor the space that rule needs. */
+.tealdoc-sidebar li.tealdoc-sidebar-section:first-child {
+    margin-top: 0 !important;
+    padding-top: 0;
+    border-top: 0;
 }
 
 .tealdoc-sidebar-section details {
@@ -87,6 +97,7 @@ return [[
     padding: 0.22rem 1.2rem 0 0.55rem;
     color: var(--tealdoc-sidebar-heading-color);
     cursor: pointer;
+    font-family: var(--tealdoc-sidebar-font-family);
     font-size: var(--tealdoc-sidebar-heading-font-size);
     font-weight: var(--tealdoc-sidebar-heading-font-weight);
     list-style: none;
@@ -117,7 +128,8 @@ return [[
 
 .tealdoc-sidebar-section ul {
     margin: 0;
-    padding: var(--tealdoc-sidebar-nested-top-padding) 0 0;
+    padding: var(--tealdoc-sidebar-nested-top-padding) 0 0
+        var(--tealdoc-sidebar-nested-indent);
     border-left: 0;
 }
 
@@ -140,19 +152,24 @@ return [[
     padding: 0;
 }
 
+/* A heading that does not fit wraps rather than being cut off: the outline is
+ * a reader's map of the page, and half a title is not one. Two lines is the
+ * limit, after which the rest is elided. */
 .tealdoc-outline a {
     position: relative;
-    display: block;
+    display: -webkit-box;
     overflow: hidden;
     padding: var(--tealdoc-outline-item-padding);
     color: var(--tealdoc-text-muted);
+    font-family: var(--tealdoc-outline-font-family);
     font-size: var(--tealdoc-outline-font-size);
     font-weight: var(--tealdoc-outline-font-weight);
-    line-height: 1.25;
+    line-height: 1.3;
     text-decoration: none;
     text-overflow: ellipsis;
     transition: color 120ms ease;
-    white-space: nowrap;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
 }
 
 .tealdoc-outline a:hover,
@@ -174,7 +191,7 @@ return [[
 .tealdoc-outline .level-3 a {
     padding-left: 0.75rem;
     color: var(--tealdoc-text-faint);
-    font-size: 0.61rem;
+    font-size: var(--tealdoc-outline-nested-font-size);
 }
 
 .tealdoc-outline .level-3 a:hover,

--- a/build/tealdoc/generator/site/css/responsive.lua
+++ b/build/tealdoc/generator/site/css/responsive.lua
@@ -170,7 +170,7 @@ return [[
     }
 
     .tealdoc-hero-copy h1 {
-        font-size: clamp(2.8rem, 14vw, 4.5rem);
+        font-size: var(--tealdoc-hero-name-size-narrow);
     }
 
     .tealdoc-hero-image {

--- a/build/tealdoc/generator/site/css/tokens.lua
+++ b/build/tealdoc/generator/site/css/tokens.lua
@@ -15,6 +15,7 @@ return [[
     --tealdoc-light-text: var(--vp-c-text-1, #213547);
     --tealdoc-light-text-muted: var(--vp-c-text-2, #67676c);
     --tealdoc-light-text-faint: var(--vp-c-text-3, #929295);
+    --tealdoc-light-sidebar-background: var(--tealdoc-light-background-alt);
     --tealdoc-dark-accent: var(--vp-c-brand-1, #5ad9e0);
     --tealdoc-dark-accent-contrast: #102f33;
     --tealdoc-dark-accent-hover: var(--vp-c-brand-2, #7ce4e9);
@@ -29,6 +30,7 @@ return [[
     --tealdoc-dark-text: var(--vp-c-text-1, #dfdfd6);
     --tealdoc-dark-text-muted: var(--vp-c-text-2, #a8a8a3);
     --tealdoc-dark-text-faint: var(--vp-c-text-3, #6a6a71);
+    --tealdoc-dark-sidebar-background: var(--tealdoc-dark-background-alt);
     --tealdoc-accent: var(--tealdoc-light-accent);
     --tealdoc-accent-contrast: var(--tealdoc-light-accent-contrast);
     --tealdoc-accent-hover: var(--tealdoc-light-accent-hover);
@@ -47,8 +49,11 @@ return [[
     --tealdoc-code-background: var(--tealdoc-light-code-background);
     --tealdoc-code-block-font-size: 0.8rem;
     --tealdoc-code-block-radius: 8px;
+    --tealdoc-code-block-padding: 0.8rem 0.9rem;
     --tealdoc-inline-code-font-size: 0.91em;
-    --tealdoc-inline-code-padding: 0.12rem;
+    --tealdoc-inline-code-padding: 0.1em 0.35em;
+    --tealdoc-inline-code-radius: 4px;
+    --tealdoc-inline-code-background: var(--tealdoc-code-background);
     --tealdoc-content-font-size: 0.8rem;
     --tealdoc-content-gutter: 5rem;
     --tealdoc-content-padding-top: 1.25rem;
@@ -89,29 +94,47 @@ return [[
         monospace
     );
     --tealdoc-header-height: var(--vp-nav-height, 64px);
+    --tealdoc-header-background: color-mix(
+        in srgb,
+        var(--tealdoc-background) 92%,
+        transparent
+    );
+    --tealdoc-header-color: var(--tealdoc-text);
+    --tealdoc-header-muted-color: var(--tealdoc-text-muted);
+    --tealdoc-header-border: var(--tealdoc-border);
+    --tealdoc-header-control-background: var(--tealdoc-background-alt);
+    --tealdoc-sidebar-background: var(--tealdoc-light-sidebar-background);
+    --tealdoc-sidebar-font-family: var(--tealdoc-font);
+    --tealdoc-outline-font-family: var(--tealdoc-font);
     --tealdoc-layout-max-width: var(--vp-layout-max-width, 1480px);
     --tealdoc-content-width: var(--vp-content-width, 688px);
     --tealdoc-sidebar-width: var(--vp-sidebar-width, 272px);
     --tealdoc-outline-width: var(--vp-aside-width, 256px);
-    --tealdoc-sidebar-font-size: 0.64rem;
-    --tealdoc-sidebar-font-weight: 700;
-    --tealdoc-sidebar-item-padding: 0.22rem 0.55rem;
+    --tealdoc-sidebar-font-size: 0.7rem;
+    --tealdoc-sidebar-font-weight: 500;
+    --tealdoc-sidebar-active-font-weight: 600;
+    --tealdoc-sidebar-item-padding: 0.24rem 0.55rem;
     --tealdoc-sidebar-item-color: var(--tealdoc-text-muted);
     --tealdoc-sidebar-heading-color: var(--tealdoc-text);
-    --tealdoc-sidebar-heading-font-size: 0.66rem;
+    --tealdoc-sidebar-heading-font-size: 0.7rem;
     --tealdoc-sidebar-heading-font-weight: 700;
     --tealdoc-sidebar-section-border: var(--tealdoc-border);
-    --tealdoc-sidebar-section-gap: 1.9rem;
-    --tealdoc-sidebar-section-padding: 2.3rem;
-    --tealdoc-sidebar-nested-top-padding: 6px;
-    --tealdoc-outline-font-size: 0.64rem;
+    --tealdoc-sidebar-section-gap: 1.1rem;
+    --tealdoc-sidebar-section-padding: 1.1rem;
+    --tealdoc-sidebar-nested-top-padding: 4px;
+    --tealdoc-sidebar-nested-indent: 0.5rem;
+    --tealdoc-outline-font-size: 0.66rem;
     --tealdoc-outline-font-weight: 600;
     --tealdoc-outline-item-padding: 0.16rem 0;
+    --tealdoc-outline-nested-font-size: 0.61rem;
     --tealdoc-hero-glow-color: var(--tealdoc-accent);
     --tealdoc-hero-glow-size: min(46vw, 520px);
     --tealdoc-hero-glow-blur: 24px;
     --tealdoc-hero-glow-opacity: 0.68;
     --tealdoc-hero-features-gap: 2rem;
+    --tealdoc-hero-name-size: clamp(3rem, 7vw, 5.5rem);
+    --tealdoc-hero-text-size: clamp(1.3rem, 2.5vw, 2rem);
+    --tealdoc-hero-name-size-narrow: clamp(2.8rem, 14vw, 4.5rem);
     --tealdoc-home-width: 1152px;
     --tealdoc-home-gutter: 2rem;
     --tealdoc-button-brand-background: var(--tealdoc-accent);
@@ -164,6 +187,7 @@ return [[
         );
         --tealdoc-background: var(--tealdoc-dark-background);
         --tealdoc-background-alt: var(--tealdoc-dark-background-alt);
+        --tealdoc-sidebar-background: var(--tealdoc-dark-sidebar-background);
         --tealdoc-background-elv: var(--tealdoc-dark-background-elv);
         --tealdoc-border: var(--tealdoc-dark-border);
         --tealdoc-code-background: var(--tealdoc-dark-code-background);
@@ -201,6 +225,7 @@ return [[
     );
     --tealdoc-background: var(--tealdoc-dark-background);
     --tealdoc-background-alt: var(--tealdoc-dark-background-alt);
+    --tealdoc-sidebar-background: var(--tealdoc-dark-sidebar-background);
     --tealdoc-background-elv: var(--tealdoc-dark-background-elv);
     --tealdoc-border: var(--tealdoc-dark-border);
     --tealdoc-code-background: var(--tealdoc-dark-code-background);
@@ -238,6 +263,7 @@ return [[
         );
         --tealdoc-background: var(--tealdoc-light-background);
         --tealdoc-background-alt: var(--tealdoc-light-background-alt);
+        --tealdoc-sidebar-background: var(--tealdoc-light-sidebar-background);
         --tealdoc-background-elv: var(--tealdoc-light-background-elv);
         --tealdoc-border: var(--tealdoc-light-border);
         --tealdoc-code-background: var(--tealdoc-light-code-background);

--- a/build/tealdoc/generator/site/markdown.lua
+++ b/build/tealdoc/generator/site/markdown.lua
@@ -10,7 +10,6 @@ local SiteMarkdown = {}
 
 
 local escape_html = Text.escape_html
-local strip_tags = Text.strip_tags
 
 local admonition_kinds = {
    ["danger"] = "Danger",
@@ -143,59 +142,6 @@ local function site_blockquote(content)
       "</p>",
       body,
       "</aside>",
-   }
-end
-
-local function mark_inline_code_spacing(rendered)
-   local output = {}
-   local position = 1
-   while true do
-      local opening_start, opening_end = rendered:find(
-      "<code>",
-      position,
-      true)
-
-      if not opening_start then
-         table.insert(output, rendered:sub(position))
-         break
-      end
-      local closing_start, closing_end = rendered:find(
-      "</code>",
-      opening_end + 1,
-      true)
-
-      if not closing_start then
-         table.insert(output, rendered:sub(position))
-         break
-      end
-
-      table.insert(output, rendered:sub(position, opening_start - 1))
-      local classes = {}
-      if strip_tags(rendered:sub(1, opening_start - 1)):match("%S") then
-         table.insert(classes, "tealdoc-inline-code-before")
-      end
-      if strip_tags(rendered:sub(closing_end + 1)):match("%S") then
-         table.insert(classes, "tealdoc-inline-code-after")
-      end
-      if #classes > 0 then
-         table.insert(
-         output,
-         '<code class="' .. table.concat(classes, " ") .. '">')
-
-      else
-         table.insert(output, "<code>")
-      end
-      table.insert(output, rendered:sub(opening_end + 1, closing_end))
-      position = closing_end + 1
-   end
-   return table.concat(output)
-end
-
-local function site_paragraph(content)
-   return {
-      "<p>",
-      mark_inline_code_spacing(rope_to_string(content)),
-      "</p>",
    }
 end
 
@@ -333,10 +279,12 @@ function SiteMarkdown.render(
             ">",
          }
       end,
-      paragraph = site_paragraph,
    })
    builder:md(markdown)
    local html = builder:build()
+
+
+   html = html:gsub("\n+(</code></pre>)", "%1")
    local function highlight_code(
       language,
       links)

--- a/spec/generator/html/generator_spec.lua
+++ b/spec/generator/html/generator_spec.lua
@@ -95,4 +95,117 @@ describe("HTML generator", function()
             true
         ))
     end)
+
+    it("tabulates parameters and returns", function()
+        local env = DefaultEnv.init()
+        env.no_warnings_on_missing = true
+        tealdoc.process_text([[
+            local record api
+                record Handle
+                end
+            end
+
+            --- Open a handle.
+            --- @param name What to open.
+            --- @param mode How to open it.
+            --- @return The handle.
+            function api.open(name: string, mode: integer): api.Handle
+                return nil
+            end
+
+            return api
+        ]], "api.tl", env)
+
+        local builder = HTMLBuilder.init()
+        local ctx = {
+            builder = builder,
+            module_name = "api",
+            path_mode = "relative",
+            env = env,
+            url_for_path = function(path)
+                return HTMLGenerator.url_for_path(path, "api", env)
+            end,
+        }
+        local item = env.registry["api.open"]
+
+        for _, phase in ipairs(HTMLGenerator.item_phases["function"]) do
+            if phase.name == "function_params"
+                or phase.name == "function_returns"
+            then
+                phase.run(ctx, item)
+            end
+        end
+
+        local html = builder:build()
+
+        assert.is_truthy(html:find(
+            "<thead><tr><th>Name</th><th>Type</th><th>Description</th></tr>"
+                .. "</thead>",
+            1,
+            true
+        ), html)
+        assert.is_truthy(html:find(
+            "<tr><td><code>name</code></td><td><code>string</code></td>"
+                .. "<td>What to open.</td></tr>",
+            1,
+            true
+        ), html)
+        assert.is_truthy(html:find(
+            "<tr><td><code>mode</code></td><td><code>integer</code></td>"
+                .. "<td>How to open it.</td></tr>",
+            1,
+            true
+        ), html)
+        assert.is_truthy(html:find(
+            "<thead><tr><th>Type</th><th>Description</th></tr></thead>",
+            1,
+            true
+        ), html)
+        assert.is_truthy(html:find(
+            "<tr><td><code>api.Handle</code></td>"
+                .. "<td>The handle.</td></tr>",
+            1,
+            true
+        ), html)
+        -- Nothing survives from the lists the tables replaced.
+        assert.is_nil(html:find("<ul>", 1, true))
+        assert.is_nil(html:find("<ol>", 1, true))
+    end)
+
+    it("leaves a cell empty when a row has nothing to put in it", function()
+        local env = DefaultEnv.init()
+        env.no_warnings_on_missing = true
+        tealdoc.process_text([[
+            local record api
+                --- Reset everything.
+                reset: function(count: integer)
+            end
+
+            return api
+        ]], "api.tl", env)
+
+        local builder = HTMLBuilder.init()
+        local ctx = {
+            builder = builder,
+            module_name = "api",
+            path_mode = "relative",
+            env = env,
+            url_for_path = function(path)
+                return HTMLGenerator.url_for_path(path, "api", env)
+            end,
+        }
+        local item = env.registry["api.reset"]
+
+        for _, phase in ipairs(HTMLGenerator.item_phases["function"]) do
+            if phase.name == "function_params" then
+                phase.run(ctx, item)
+            end
+        end
+
+        assert.is_truthy(builder:build():find(
+            "<tr><td></td><td><code>integer</code></td><td></td></tr>",
+            1,
+            true
+        ))
+    end)
 end)

--- a/spec/generator/markdown_spec.lua
+++ b/spec/generator/markdown_spec.lua
@@ -165,17 +165,17 @@ describe("Markdown generator", function()
         os.remove(linked_output)
 
         assert.is_truthy(linked_markdown:find(
-            "([`types.Options`](/modules/types#types.Options))",
+            "| [`types.Options`](/modules/types#types.Options) |",
             assert(linked_markdown:find("## api.copy", 1, true)),
             true
         ), linked_markdown)
         assert.is_truthy(linked_markdown:find(
-            "([`PublicOptions`](#api.PublicOptions))",
+            "| [`PublicOptions`](#api.PublicOptions) |",
             assert(linked_markdown:find("## api.copyPublic", 1, true)),
             true
         ), linked_markdown)
         assert.is_truthy(linked_markdown:find(
-            "([`PrivateOptions`](/modules/types#types.Options))",
+            "| [`PrivateOptions`](/modules/types#types.Options) |",
             assert(linked_markdown:find("## api.copyPrivate", 1, true)),
             true
         ), linked_markdown)
@@ -187,12 +187,12 @@ describe("Markdown generator", function()
         assert.is_truthy(linked_markdown:find("## api.Payload.value", 1, true))
         assert.is_falsy(linked_markdown:find("api.Payload: Payload", 1, true))
         assert.is_truthy(linked_markdown:find(
-            "([`Payload`](#api.Payload))",
+            "| [`Payload`](#api.Payload) |",
             assert(linked_markdown:find("## api.copyPayload", 1, true)),
             true
         ), linked_markdown)
         assert.is_truthy(linked_markdown:find(
-            "([`Window`](/modules/window#window))",
+            "| [`Window`](/modules/window#window) |",
             assert(linked_markdown:find("## api.messageBox", 1, true)),
             true
         ), linked_markdown)
@@ -202,10 +202,148 @@ describe("Markdown generator", function()
             true
         ), linked_markdown)
         assert.is_truthy(linked_markdown:find(
-            "([`Window`](/modules/window#window)`<T>`)",
+            "| [`Window`](/modules/window#window)`<T>` |",
             assert(linked_markdown:find("## api.generic", 1, true)),
             true
         ), linked_markdown)
         assert.is_falsy(linked_markdown:find("``T``", 1, true))
+    end)
+
+    it("tabulates parameters, returns and type parameters", function()
+        local env = DefaultEnv.init()
+        env.no_warnings_on_missing = true
+        tealdoc.process_text([[
+            local record api
+                record Handle
+                end
+            end
+
+            --- Open a handle.
+            --- @param name What to open.
+            --- @param mode How to open it.
+            --- @return The handle.
+            function api.open(name: string, mode: integer): api.Handle
+                return nil
+            end
+
+            --- Returns a value unchanged.
+            --- @param value The value to return.
+            --- @return The same value.
+            function api.identity<T>(value: T): T
+                return value
+            end
+
+            return api
+        ]], "api.tl", env)
+
+        local output = os.tmpname()
+        MarkdownGenerator.init(output):run(env)
+        local file = assert(io.open(output, "r"))
+        local markdown = file:read("*a")
+        file:close()
+        os.remove(output)
+
+        assert.is_truthy(markdown:find([[
+| Name | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | What to open. |
+| `mode` | `integer` | How to open it. |
+]], 1, true), markdown)
+
+        assert.is_truthy(markdown:find([[
+| Type | Description |
+| --- | --- |
+| `api.Handle` | The handle. |
+]], 1, true), markdown)
+
+        assert.is_truthy(markdown:find([[
+| Name | Constraint | Description |
+| --- | --- | --- |
+| `T` |  |  |
+]], 1, true), markdown)
+    end)
+
+    it("keeps a union type inside its own cell", function()
+        local env = DefaultEnv.init()
+        env.no_warnings_on_missing = true
+        tealdoc.process_text([[
+            local record api
+                find: function(string): string | nil
+            end
+
+            return api
+        ]], "api.tl", env)
+
+        local output = os.tmpname()
+        MarkdownGenerator.init(output):run(env)
+        local file = assert(io.open(output, "r"))
+        local markdown = file:read("*a")
+        file:close()
+        os.remove(output)
+
+        -- A literal pipe would end the cell in the middle of the type.
+        assert.is_truthy(markdown:find(
+            "| <code>string &#124; nil</code> |",
+            1,
+            true
+        ), markdown)
+    end)
+
+    it("keeps angle brackets readable in a cell that carries a union", function()
+        local env = DefaultEnv.init()
+        env.no_warnings_on_missing = true
+        tealdoc.process_text([[
+            local record api
+                record Handle<T>
+                end
+
+                find: function(string): Handle<string> | nil
+            end
+
+            return api
+        ]], "api.tl", env)
+
+        local output = os.tmpname()
+        MarkdownGenerator.init(output):run(env)
+        local file = assert(io.open(output, "r"))
+        local markdown = file:read("*a")
+        file:close()
+        os.remove(output)
+
+        -- The code element is HTML, so its contents are escaped the way a code
+        -- span would have had them escaped on the reader's behalf.
+        assert.is_truthy(markdown:find(
+            "| <code>Handle&lt;string&gt; &#124; nil</code> |",
+            1,
+            true
+        ), markdown)
+    end)
+
+    it("folds a description written over several lines onto its row", function()
+        local env = DefaultEnv.init()
+        env.no_warnings_on_missing = true
+        tealdoc.process_text([[
+            local record api
+                --- Open a handle.
+                --- @param name What to open. The name is looked up in the
+                ---     registry first.
+                open: function(name: string)
+            end
+
+            return api
+        ]], "api.tl", env)
+
+        local output = os.tmpname()
+        MarkdownGenerator.init(output):run(env)
+        local file = assert(io.open(output, "r"))
+        local markdown = file:read("*a")
+        file:close()
+        os.remove(output)
+
+        assert.is_truthy(markdown:find(
+            "| What to open. The name is looked up in the registry first. |",
+            1,
+            true
+        ), markdown)
     end)
 end)

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -306,6 +306,44 @@ describe("Site generator", function()
         remove_tree(output)
     end)
 
+    it("carries a union type through a parameter table to the page", function()
+        local env = DefaultEnv.init()
+        env.no_warnings_on_missing = true
+        tealdoc.process_text([[
+            local record api
+                --- Finds a thing by name.
+                --- @param name What to look for.
+                --- @return The thing, or nil when there is none.
+                find: function(name: string): string | nil
+            end
+
+            return api
+        ]], "api.tl", env)
+
+        local output = os.tmpname()
+        os.remove(output)
+        SiteGenerator.build(output, env, {
+            title = "Union",
+            pages = {
+                {path = "", title = "Home"},
+                {path = "api", title = "API", api = "api"},
+            },
+        })
+
+        local html = read_file(output .. "/api/index.html")
+
+        -- The pipe that spells the union is also the cell separator, so it only
+        -- reaches the page if the row it was written into kept it out of the way.
+        assert.is_truthy(html:find("<th>Name</th>", 1, true), html)
+        assert.is_truthy(html:find(
+            "<td><code>string | nil</code></td>",
+            1,
+            true
+        ), html)
+
+        remove_tree(output)
+    end)
+
     it("prefers a dedicated page over a parent-page item route", function()
         local env = DefaultEnv.init()
         env.no_warnings_on_missing = true
@@ -1105,7 +1143,7 @@ print(value)
             true
         ), api)
         assert.is_truthy(api:find(
-            '(<a href="/modules/window/"><code>Window</code></a>)',
+            '<td><a href="/modules/window/"><code>Window</code></a></td>',
             1,
             true
         ), api)

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -657,7 +657,8 @@ print(value)
         attached_example_file:close()
         local custom_css = os.tmpname()
         local custom_css_file = assert(io.open(custom_css, "w"))
-        custom_css_file:write([[@import url("https://example.test/font.css");
+        custom_css_file:write([[/* A comment, which CSS lets stand before an import. */
+@import url("https://example.test/font.css");
 
 .project-rule {
     color: rebeccapurple;
@@ -924,20 +925,17 @@ print(value)
         assert.is_truthy(home:find('class="tealdoc-feature"', 1, true))
         assert.is_truthy(home:find("<strong>source</strong>", 1, true))
         assert.is_truthy(home:find(
-            '<p><code class="tealdoc-inline-code-after">' ..
-                "leading</code> text.</p>",
+            "<p><code>leading</code> text.</p>",
             1,
             true
         ))
         assert.is_truthy(home:find(
-            '<p>Text <code class="tealdoc-inline-code-before ' ..
-                'tealdoc-inline-code-after">middle</code> text.</p>',
+            "<p>Text <code>middle</code> text.</p>",
             1,
             true
         ))
         assert.is_truthy(home:find(
-            '<p>Text <code class="tealdoc-inline-code-before">' ..
-                "trailing</code></p>",
+            "<p>Text <code>trailing</code></p>",
             1,
             true
         ))
@@ -1075,8 +1073,7 @@ print(value)
         assert.is_falsy(api:find("Public APIs in", 1, true))
         assert.is_truthy(window_html:find("window Reference", 1, true))
         assert.is_truthy(window_html:find(
-            'Public APIs in <code class="tealdoc-inline-code-before ' ..
-                'tealdoc-inline-code-after">window</code>.',
+            "Public APIs in <code>window</code>.",
             1,
             true
         ))
@@ -1112,7 +1109,11 @@ print(value)
             1,
             true
         ), api)
-        assert.is_truthy(api:find(">↳ messageBox</a>", 1, true), api)
+        -- Every entry under a reference section drops the namespace its
+        -- siblings share, the one that opens the section included.
+        assert.is_truthy(api:find(">Options</a>", 1, true), api)
+        assert.is_truthy(api:find(">messageBox</a>", 1, true), api)
+        assert.is_falsy(api:find("↳", 1, true))
         assert.is_truthy(api:find(
             '<a class="tealdoc-code-link" href="/modules/window/"><span class="token class-name tealdoc-token-type">Window</span></a>',
             1,
@@ -1247,7 +1248,8 @@ print(value)
             true
         ))
         assert.is_truthy(css:find(
-            '@import url("https://example.test/font.css");\n\n:root {',
+            "/* A comment, which CSS lets stand before an import. */\n\n" ..
+                '@import url("https://example.test/font.css");\n\n:root {',
             1,
             true
         ))
@@ -1294,27 +1296,16 @@ print(value)
         ))
         assert.is_truthy(css:find(
             ".tealdoc-content :not(pre) > code {\n" ..
-                "    padding: 0;\n" ..
-                "    background: transparent;\n" ..
+                "    padding: var(--tealdoc-inline-code-padding);\n" ..
+                "    border-radius: var(--tealdoc-inline-code-radius);\n" ..
+                "    background: var(--tealdoc-inline-code-background);\n" ..
                 "    font-size: var(--tealdoc-inline-code-font-size);\n" ..
                 "    font-weight: 550;",
             1,
             true
         ))
-        assert.is_truthy(css:find(
-            "> code.tealdoc-inline-code-before {\n" ..
-                "    padding-inline-start: " ..
-                "var(--tealdoc-inline-code-padding);",
-            1,
-            true
-        ))
-        assert.is_truthy(css:find(
-            "> code.tealdoc-inline-code-after {\n" ..
-                "    padding-inline-end: " ..
-                "var(--tealdoc-inline-code-padding);",
-            1,
-            true
-        ))
+        assert.is_falsy(css:find("tealdoc-inline-code-before", 1, true))
+        assert.is_falsy(css:find("tealdoc-inline-code-after", 1, true))
         assert.is_truthy(css:find(
             '.tealdoc-content code[class*="language-"] {\n' ..
                 "    color: var(--tealdoc-syntax-foreground);\n" ..
@@ -1327,7 +1318,7 @@ print(value)
         assert.is_truthy(css:find(
             ".tealdoc-content pre {\n" ..
                 "    overflow: auto;\n" ..
-                "    padding: 0.5rem 0.6rem;\n" ..
+                "    padding: var(--tealdoc-code-block-padding);\n" ..
                 "    border: 1px solid var(--tealdoc-border);\n" ..
                 "    border-radius: var(--tealdoc-code-block-radius);",
             1,
@@ -1397,6 +1388,7 @@ print(value)
                 "    padding: var(--tealdoc-sidebar-item-padding);\n" ..
                 "    color: var(--tealdoc-sidebar-item-color);\n" ..
                 "    border-radius: 6px;\n" ..
+                "    font-family: var(--tealdoc-sidebar-font-family);\n" ..
                 "    font-size: var(--tealdoc-sidebar-font-size);\n" ..
                 "    font-weight: var(--tealdoc-sidebar-font-weight);",
             1,
@@ -1428,7 +1420,7 @@ print(value)
         assert.is_truthy(css:find(
             "--tealdoc-sidebar-item-color: var(--tealdoc-text-muted);\n" ..
                 "    --tealdoc-sidebar-heading-color: var(--tealdoc-text);\n" ..
-                "    --tealdoc-sidebar-heading-font-size: 0.66rem;\n" ..
+                "    --tealdoc-sidebar-heading-font-size: 0.7rem;\n" ..
                 "    --tealdoc-sidebar-heading-font-weight: 700;\n" ..
                 "    --tealdoc-sidebar-section-border: var(--tealdoc-border);",
             1,
@@ -1437,7 +1429,8 @@ print(value)
         assert.is_truthy(css:find(
             ".tealdoc-sidebar-section ul {\n" ..
                 "    margin: 0;\n" ..
-                "    padding: var(--tealdoc-sidebar-nested-top-padding) 0 0;\n" ..
+                "    padding: var(--tealdoc-sidebar-nested-top-padding) 0 0\n" ..
+                "        var(--tealdoc-sidebar-nested-indent);\n" ..
                 "    border-left: 0;",
             1,
             true
@@ -1449,7 +1442,7 @@ print(value)
             true
         ))
         assert.is_truthy(css:find(
-            "--tealdoc-outline-font-size: 0.64rem",
+            "--tealdoc-outline-font-size: 0.66rem",
             1,
             true
         ))
@@ -1464,14 +1457,16 @@ print(value)
             true
         ))
         assert.is_truthy(css:find(
-            ".tealdoc-outline .level-3 a {\n    padding-left: 0.75rem;\n    color: var(--tealdoc-text-faint);\n    font-size: 0.61rem;",
+            ".tealdoc-outline .level-3 a {\n    padding-left: 0.75rem;\n" ..
+                "    color: var(--tealdoc-text-faint);\n" ..
+                "    font-size: var(--tealdoc-outline-nested-font-size);",
             1,
             true
         ))
         assert.is_truthy(css:find("text-overflow: ellipsis", 1, true))
         assert.is_truthy(api:find('title="api Reference"', 1, true), api)
         assert.is_truthy(css:find(
-            "box-shadow: -100vw 0 0 100vw var(--tealdoc-background-alt)",
+            "box-shadow: -100vw 0 0 100vw var(--tealdoc-sidebar-background)",
             1,
             true
         ))

--- a/src/tealdoc/default_env.tl
+++ b/src/tealdoc/default_env.tl
@@ -586,6 +586,16 @@ function DefaultEnv.init(): tealdoc.Env
         end
     }
 
+    -- Parameters, returns and type parameters are tabulated rather than listed,
+    -- so that a reader comparing several of them reads down a column instead of
+    -- across a sentence each. The first column is whatever names the row, and
+    -- the description is last so it takes the width the other columns leave. A
+    -- return has no name in Teal, so its table starts at the type and lets row
+    -- order say the position a number would have.
+    local type_param_columns: {string} = {"Name", "Constraint", "Description"}
+    local param_columns: {string} = {"Name", "Type", "Description"}
+    local return_columns: {string} = {"Type", "Description"}
+
     local type_params_phase: Generator.Phase = {
         name = "type_params",
         run = function(ctx: Generator.Phase.Context, item: tealdoc.Item)
@@ -596,26 +606,31 @@ function DefaultEnv.init(): tealdoc.Env
             end
 
             ctx.builder:h4(attr("header"), "Type Parameters")
-            ctx.builder:unordered_list(function(list_item: function(content: function))
+            ctx.builder:table(type_param_columns, function(row: function(...: function))
                 for _, typearg in ipairs(item.typeargs) do
-                    list_item(function()
-                        ctx.builder:b(function()
+                    row(
+                        function()
                             ctx.builder:code(attr("name"), typearg.name or "?")
-                        end)
-
-                        if typearg.constraint then
-                            ctx.builder:text(attr("constraint"), " ( is ", function() ctx.builder:code(typearg.constraint) end, ")")
+                        end,
+                        function()
+                            if typearg.constraint then
+                                ctx.builder:code(
+                                    attr("constraint"),
+                                    typearg.constraint
+                                )
+                            end
+                        end,
+                        function()
+                            if typearg.description then
+                                ctx.builder:text(attr("description"), function()
+                                    ctx.builder:md(markdown_with_type_links(
+                                        ctx,
+                                        typearg.description
+                                    ))
+                                end)
+                            end
                         end
-
-                        if typearg.description then
-                            ctx.builder:text(attr("description"), " — ", function()
-                                ctx.builder:md(markdown_with_type_links(
-                                    ctx,
-                                    typearg.description
-                                ))
-                            end)
-                        end
-                    end)
+                    )
                 end
             end)
         end
@@ -631,28 +646,31 @@ function DefaultEnv.init(): tealdoc.Env
             end
 
             markdown_section(ctx, item, "Type Parameters")
-            ctx.builder:unordered_list(function(list_item: function(content: function))
+            ctx.builder:table(type_param_columns, function(row: function(...: function))
                 for _, typearg in ipairs(item.typeargs) do
-                    list_item(function()
-                        ctx.builder:b(function()
+                    row(
+                        function()
                             ctx.builder:code(attr("name"), typearg.name or "?")
-                        end)
-
-                        if typearg.constraint then
-                            ctx.builder:text(attr("constraint"), " ( is ", function()
-                                ctx.builder:code(typearg.constraint)
-                            end, ")")
+                        end,
+                        function()
+                            if typearg.constraint then
+                                ctx.builder:code(
+                                    attr("constraint"),
+                                    typearg.constraint
+                                )
+                            end
+                        end,
+                        function()
+                            if typearg.description then
+                                ctx.builder:text(attr("description"), function()
+                                    ctx.builder:md(markdown_with_type_links(
+                                        ctx,
+                                        typearg.description
+                                    ))
+                                end)
+                            end
                         end
-
-                        if typearg.description then
-                            ctx.builder:text(attr("description"), " — ", function()
-                                ctx.builder:md(markdown_with_type_links(
-                                    ctx,
-                                    typearg.description
-                                ))
-                            end)
-                        end
-                    end)
+                    )
                 end
             end)
         end
@@ -668,24 +686,28 @@ function DefaultEnv.init(): tealdoc.Env
             end
 
             ctx.builder:h4(attr("name"), "Parameters")
-            ctx.builder:unordered_list(function(list_item: function(content: function)) -- TODO!
+            ctx.builder:table(param_columns, function(row: function(...: function))
                 for _, param in ipairs(item.params) do
-                    list_item(function()
-                        if param.name then
-                            ctx.builder:b(function()
+                    row(
+                        function()
+                            if param.name then
                                 ctx.builder:code(attr("name"), param.name)
-                            end)
+                            end
+                        end,
+                        function()
+                            ctx.builder:code(attr("type"), param.type or "?")
+                        end,
+                        function()
+                            if param.description then
+                                ctx.builder:text(attr("description"), function()
+                                    ctx.builder:md(markdown_with_type_links(
+                                        ctx,
+                                        param.description
+                                    ))
+                                end)
+                            end
                         end
-                        ctx.builder:text(attr("type"), " (", function() ctx.builder:code(param.type or "?") end, ")")
-                        if param.description then
-                            ctx.builder:text(attr("description"), " — ", function()
-                                ctx.builder:md(markdown_with_type_links(
-                                    ctx,
-                                    param.description
-                                ))
-                            end)
-                        end
-                    end)
+                    )
                 end
             end)
         end
@@ -702,26 +724,34 @@ function DefaultEnv.init(): tealdoc.Env
                 return
             end
 
-            ctx.builder:unordered_list(function(list_item: function(content: function))
+            ctx.builder:table(param_columns, function(row: function(...: function))
                 for _, param in ipairs(item.params) do
-                    list_item(function()
-                        if param.name then
-                            ctx.builder:b(function()
+                    row(
+                        function()
+                            if param.name then
                                 ctx.builder:code(attr("name"), param.name)
-                            end)
-                        end
-                        ctx.builder:text(attr("type"), " (", function()
-                            markdown_type(ctx, param.type or "?", param.type_references)
-                        end, ")")
-                        if param.description then
-                            ctx.builder:text(attr("description"), " — ", function()
-                                ctx.builder:md(markdown_with_type_links(
+                            end
+                        end,
+                        function()
+                            ctx.builder:text(attr("type"), function()
+                                markdown_type(
                                     ctx,
-                                    param.description
-                                ))
+                                    param.type or "?",
+                                    param.type_references
+                                )
                             end)
+                        end,
+                        function()
+                            if param.description then
+                                ctx.builder:text(attr("description"), function()
+                                    ctx.builder:md(markdown_with_type_links(
+                                        ctx,
+                                        param.description
+                                    ))
+                                end)
+                            end
                         end
-                    end)
+                    )
                 end
             end)
         end
@@ -738,19 +768,23 @@ function DefaultEnv.init(): tealdoc.Env
 
             ctx.builder:h4(attr("header"), "Returns")
 
-            ctx.builder:ordered_list(function(list_item: function(content: function))
+            ctx.builder:table(return_columns, function(row: function(...: function))
                 for _, ret in ipairs(item.returns) do
-                    list_item(function()
-                        ctx.builder:text(attr("type"), "(", function() ctx.builder:code(ret.type or "?") end, ")")
-                        if ret.description then
-                            ctx.builder:text(attr("description"), " — ", function()
-                                ctx.builder:md(markdown_with_type_links(
-                                    ctx,
-                                    ret.description
-                                ))
-                            end)
+                    row(
+                        function()
+                            ctx.builder:code(attr("type"), ret.type or "?")
+                        end,
+                        function()
+                            if ret.description then
+                                ctx.builder:text(attr("description"), function()
+                                    ctx.builder:md(markdown_with_type_links(
+                                        ctx,
+                                        ret.description
+                                    ))
+                                end)
+                            end
                         end
-                    end)
+                    )
                 end
             end)
         end
@@ -767,21 +801,29 @@ function DefaultEnv.init(): tealdoc.Env
                 return
             end
 
-            ctx.builder:ordered_list(function(list_item: function(content: function))
+            ctx.builder:table(return_columns, function(row: function(...: function))
                 for _, ret in ipairs(item.returns) do
-                    list_item(function()
-                        ctx.builder:text(attr("type"), "(", function()
-                            markdown_type(ctx, ret.type or "?", ret.type_references)
-                        end, ")")
-                        if ret.description then
-                            ctx.builder:text(attr("description"), " — ", function()
-                                ctx.builder:md(markdown_with_type_links(
+                    row(
+                        function()
+                            ctx.builder:text(attr("type"), function()
+                                markdown_type(
                                     ctx,
-                                    ret.description
-                                ))
+                                    ret.type or "?",
+                                    ret.type_references
+                                )
                             end)
+                        end,
+                        function()
+                            if ret.description then
+                                ctx.builder:text(attr("description"), function()
+                                    ctx.builder:md(markdown_with_type_links(
+                                        ctx,
+                                        ret.description
+                                    ))
+                                end)
+                            end
                         end
-                    end)
+                    )
                 end
             end)
         end

--- a/src/tealdoc/generator.tl
+++ b/src/tealdoc/generator.tl
@@ -31,6 +31,12 @@ local record Generator
         ordered_list: function(self, content: function(item: function(content: function))): Builder
         unordered_list: function(self, content: function(item: function(content: function))): Builder
 
+        -- Write a table. `headers` names the columns, and `content` is called
+        -- with a `row` function taking one content function per column. Every
+        -- row must be given as many cells as there are headers; a cell with
+        -- nothing to say writes nothing and leaves the cell empty.
+        table: function(self, headers: {string}, content: function(row: function(...: function))): Builder
+
         b: function(self, ...: Content): Builder
         i: function(self, ...: Content): Builder
         code: function(self, ...: Content): Builder

--- a/src/tealdoc/generator/html/builder.tl
+++ b/src/tealdoc/generator/html/builder.tl
@@ -189,6 +189,33 @@ HTMLBuilder.unordered_list = function(self, content: function(item: function(con
     return self
 end
 
+HTMLBuilder.table = function(self, headers: {string}, content: function(row: function(...: function))): HTMLBuilder
+    local row = function(...: function)
+        self:rawtext("<tr>")
+        for i = 1, select("#", ...) do
+            self:rawtext("<td>")
+            local write = (select(i, ...)) as function
+            write()
+            self:rawtext("</td>")
+        end
+        self:rawline("</tr>")
+    end
+
+    self:rawline("<table>")
+    self:rawtext("<thead><tr>")
+    for _, header in ipairs(headers) do
+        self:rawtext("<th>")
+        self:text(header)
+        self:rawtext("</th>")
+    end
+    self:rawline("</tr></thead>")
+    self:rawline("<tbody>")
+    content(row)
+    self:rawline("</tbody>")
+    self:rawline("</table>")
+    return self
+end
+
 HTMLBuilder.b = function(self, ...: Content): HTMLBuilder
     self:rawtext("<b>")
     self:text(...)

--- a/src/tealdoc/generator/html/default_css.tl
+++ b/src/tealdoc/generator/html/default_css.tl
@@ -29,6 +29,31 @@ return [[
     li {
         margin: 0.5em 0;
     }
+    table {
+        border-collapse: collapse;
+        margin: 0.5em 0 1.5em 0;
+        width: 100%;
+        display: block;
+        overflow-x: auto;
+    }
+    th, td {
+        border-bottom: 1px solid #e2e2e2;
+        padding: 0.4em 0.8em 0.4em 0;
+        text-align: left;
+        vertical-align: top;
+    }
+    th {
+        color: #555;
+        font-size: 0.85em;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
+    /* Every column but the last names a type or a parameter, so it should stay
+       on one line and let the description take the rest of the width. */
+    td:not(:last-child) {
+        white-space: nowrap;
+    }
     a {
         color: #007bff;
         text-decoration: none;

--- a/src/tealdoc/generator/markdown.tl
+++ b/src/tealdoc/generator/markdown.tl
@@ -155,6 +155,59 @@ MarkdownBuilder.unordered_list = function(self, content: function(item: function
     return self
 end
 
+-- A pipe table rather than a raw `<table>` element, because Markdown renders
+-- the contents of a cell and passes the contents of a raw HTML block through
+-- untouched, and a description is Markdown.
+MarkdownBuilder.table = function(self, headers: {string}, content: function(row: function(...: function))): MarkdownBuilder
+    -- Each cell is written into a buffer of its own so the row separator can be
+    -- taken out of it. A union type is spelled with `|`, and a literal one
+    -- would end the cell in the middle of the type. The entity is what survives
+    -- the readers that consume this, which take a backslash before a pipe as an
+    -- ordinary backslash and end the cell anyway. A code span carrying one has
+    -- to become a `code` element for the same reason: a span renders what is
+    -- inside it literally, entity and all.
+    local function cell(write: function): string
+        local outer = self.output
+        self.output = {}
+        write()
+        local written = table.concat(self.output, "")
+        self.output = outer
+
+        written = written:gsub("`([^`]*)`", function(inner: string): string
+            if not inner:find("|", 1, true) then
+                return "`" .. inner .. "`"
+            end
+            return "<code>" ..
+                (Text.escape_html(inner):gsub("|", "&#124;")) ..
+                "</code>"
+        end)
+
+        -- A row is one line, so a description written over several is folded
+        -- onto one here.
+        return (written:gsub("|", "&#124;"):gsub("%s*\n%s*", " "))
+    end
+
+    local row = function(...: function)
+        local cells: {string} = {}
+        for i = 1, select("#", ...) do
+            table.insert(cells, cell((select(i, ...)) as function))
+        end
+        self:rawline("| ", table.concat(cells, " | "), " |")
+    end
+
+    local rule: {string} = {}
+    for _ = 1, #headers do
+        table.insert(rule, "---")
+    end
+
+    self:line()
+    self:rawline("| ", table.concat(headers, " | "), " |")
+    self:rawline("| ", table.concat(rule, " | "), " |")
+    content(row)
+    self:line()
+    return self
+end
+
 MarkdownBuilder.b = function(self, ...: Content): MarkdownBuilder
     self:rawtext("**")
     self:text(...)

--- a/src/tealdoc/generator/site.tl
+++ b/src/tealdoc/generator/site.tl
@@ -61,23 +61,40 @@ local function read_file(path: string): string
     return contents
 end
 
+-- A custom sheet is appended to the generated one, so its `@import` rules move
+-- to the front: an import that follows a style rule is dropped by the browser,
+-- and a web font asked for that way would silently never arrive. CSS lets a
+-- comment stand before an import, and a sheet worth reading opens with one, so
+-- the scan reads past comments rather than stopping at the first, and carries
+-- them along so the author keeps what they wrote.
 local function append_custom_css(css: string, custom: string): string
+    local preamble: {string} = {}
     local imports: {string} = {}
+    local body = custom
     while true do
-        local first, last, statement = custom:find(
-            "^%s*(@import%s+[^;]+;)"
-        )
-        if not first then
-            break
+        local remainder = body:gsub("^%s+", "")
+        local comment = remainder:match("^(/%*.-%*/)")
+        if comment then
+            table.insert(preamble, comment)
+            body = remainder:sub(#comment + 1)
+        else
+            local first, last, statement = remainder:find("^(@import%s+[^;]+;)")
+            if not first then
+                break
+            end
+            table.insert(imports, statement)
+            body = remainder:sub(last + 1)
         end
-        table.insert(imports, statement)
-        custom = custom:sub(last + 1)
     end
-    local prefix = ""
-    if #imports > 0 then
-        prefix = table.concat(imports, "\n") .. "\n\n"
+    if #imports == 0 then
+        return css .. "\n" .. custom:gsub("^%s+", "")
     end
-    return prefix .. css .. "\n" .. custom:gsub("^%s+", "")
+    local prefix = table.concat(preamble, "\n\n")
+    if prefix ~= "" then
+        prefix = prefix .. "\n\n"
+    end
+    prefix = prefix .. table.concat(imports, "\n") .. "\n\n"
+    return prefix .. css .. "\n" .. body:gsub("^%s+", "")
 end
 
 local function write_file(path: string, contents: string)
@@ -749,14 +766,21 @@ local function headings(html: string): string, string, {Heading}
                 local outline_title = title
                 if level == 2 then
                     outline_prefix = ""
-                elseif outline_prefix ~= ""
-                    and title:sub(1, #outline_prefix + 1)
-                        == outline_prefix .. "."
-                then
-                    outline_title = "↳ " ..
-                        title:sub(#outline_prefix + 2)
                 else
-                    outline_prefix = title:match("^(.*)%.") or ""
+                    -- Every entry under a section drops the namespace its
+                    -- siblings share, the first one included. The prefix comes
+                    -- from whichever entry opens the section, and applies to
+                    -- that entry too: abbreviating all but the first is what
+                    -- made the first read as the parent of the rest.
+                    if outline_prefix == "" then
+                        outline_prefix = title:match("^(.*)%.") or ""
+                    end
+                    if outline_prefix ~= ""
+                        and title:sub(1, #outline_prefix + 1)
+                            == outline_prefix .. "."
+                    then
+                        outline_title = title:sub(#outline_prefix + 2)
+                    end
                 end
                 table.insert(found, {
                     id = id,

--- a/src/tealdoc/generator/site/css/base.tl
+++ b/src/tealdoc/generator/site/css/base.tl
@@ -61,8 +61,8 @@ input {
     min-height: var(--tealdoc-header-height);
     margin: 0;
     padding: 0;
-    border-bottom: 1px solid var(--tealdoc-border);
-    background: color-mix(in srgb, var(--tealdoc-background) 92%, transparent);
+    border-bottom: 1px solid var(--tealdoc-header-border);
+    background: var(--tealdoc-header-background);
     backdrop-filter: blur(12px);
 }
 
@@ -82,7 +82,7 @@ input {
     flex: none;
     align-items: center;
     gap: 0.6rem;
-    color: var(--tealdoc-text);
+    color: var(--tealdoc-header-color);
     font-size: 1rem;
     font-weight: 650;
     letter-spacing: -0.01em;
@@ -108,7 +108,7 @@ input {
 .tealdoc-top-nav a {
     position: relative;
     padding: 0.45rem 0.65rem;
-    color: var(--tealdoc-text-muted);
+    color: var(--tealdoc-header-muted-color);
     border-radius: 7px;
     font-size: 0.875rem;
     font-weight: 500;
@@ -116,8 +116,8 @@ input {
 }
 
 .tealdoc-top-nav a:hover {
-    color: var(--tealdoc-text);
-    background: var(--tealdoc-background-alt);
+    color: var(--tealdoc-header-color);
+    background: var(--tealdoc-header-control-background);
 }
 
 .tealdoc-top-nav a[aria-current="page"] {
@@ -145,18 +145,18 @@ input {
     gap: 0.45rem;
     margin: 0 0 0 1.75rem;
     padding: 0.35rem 0.65rem;
-    color: var(--tealdoc-text-muted);
-    border: 1px solid var(--tealdoc-border);
+    color: var(--tealdoc-header-muted-color);
+    border: 1px solid var(--tealdoc-header-border);
     border-radius: 8px;
-    background: var(--tealdoc-background-alt);
+    background: var(--tealdoc-header-control-background);
     box-shadow: none;
     font-size: 0.82rem;
 }
 
 .tealdoc-search-button:hover {
-    color: var(--tealdoc-text);
-    border-color: var(--tealdoc-text-faint);
-    background: var(--tealdoc-background-alt);
+    color: var(--tealdoc-header-color);
+    border-color: var(--tealdoc-header-muted-color);
+    background: var(--tealdoc-header-control-background);
 }
 
 .tealdoc-icon-link {
@@ -168,15 +168,15 @@ input {
     justify-content: center;
     margin: 0;
     padding: 0;
-    color: var(--tealdoc-text-muted);
+    color: var(--tealdoc-header-muted-color);
     border-radius: 7px;
     cursor: pointer;
     text-decoration: none;
 }
 
 .tealdoc-icon-link:hover {
-    color: var(--tealdoc-text);
-    background: var(--tealdoc-background-alt);
+    color: var(--tealdoc-header-color);
+    background: var(--tealdoc-header-control-background);
 }
 
 .tealdoc-theme-input:focus-visible ~ .tealdoc-site .tealdoc-theme-toggle {
@@ -222,10 +222,10 @@ input {
 .tealdoc-search-button kbd {
     margin-left: auto;
     padding: 0.1rem 0.35rem;
-    color: var(--tealdoc-text-faint);
-    border: 1px solid var(--tealdoc-border);
+    color: var(--tealdoc-header-muted-color);
+    border: 1px solid var(--tealdoc-header-border);
     border-radius: 4px;
-    background: var(--tealdoc-background);
+    background: transparent;
     box-shadow: none;
     font-size: 0.68rem;
 }

--- a/src/tealdoc/generator/site/css/components.tl
+++ b/src/tealdoc/generator/site/css/components.tl
@@ -65,10 +65,17 @@ return [[
     margin-bottom: 0;
 }
 
+/* Pico lays a [role="group"] out as an inline flex row, which is right for a
+ * button group and wrong for a stack of labelled code blocks, so the display
+ * is stated here rather than left to the classless sheet. */
 .tealdoc-code-group {
+    display: block;
+    overflow: hidden;
     margin: 1.25rem 0;
     border: 1px solid var(--tealdoc-border);
+    border-radius: var(--tealdoc-code-block-radius);
     background: var(--tealdoc-code-background);
+    box-shadow: none;
 }
 
 .tealdoc-labeled-code {
@@ -96,6 +103,11 @@ return [[
     border-right: 0;
     border-bottom: 0;
     border-left: 0;
+}
+
+.tealdoc-code-group > .tealdoc-labeled-code pre {
+    border: 0;
+    border-radius: 0;
 }
 
 .tealdoc-page-nav {

--- a/src/tealdoc/generator/site/css/content.tl
+++ b/src/tealdoc/generator/site/css/content.tl
@@ -291,4 +291,26 @@ return [[
     width: 100%;
 }
 
+.tealdoc-content th,
+.tealdoc-content td {
+    padding: 0.4em 0.9em 0.4em 0;
+    vertical-align: top;
+}
+
+.tealdoc-content thead th {
+    color: var(--tealdoc-text-muted);
+    font-size: 0.82em;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+/* A parameter row is as tall as its description, and the name and the type it
+   belongs to have to stay beside the first line of that description rather
+   than float in the middle of it. Every column but the last holds one of those
+   short values, so it keeps to one line and lets the description take the
+   width that is left. */
+.tealdoc-content td:not(:last-child) {
+    white-space: nowrap;
+}
+
 ]]

--- a/src/tealdoc/generator/site/css/content.tl
+++ b/src/tealdoc/generator/site/css/content.tl
@@ -10,7 +10,7 @@ return [[
     border-radius: 0;
 }
 
-.tealdoc-content:not(.tealdoc-home-content) {
+.tealdoc-content {
     font-size: var(--tealdoc-content-font-size);
 }
 
@@ -163,12 +163,18 @@ return [[
 
 .tealdoc-content pre {
     overflow: auto;
-    padding: 0.5rem 0.6rem;
+    padding: var(--tealdoc-code-block-padding);
     border: 1px solid var(--tealdoc-border);
     border-radius: var(--tealdoc-code-block-radius);
     background: var(--tealdoc-code-background);
     font-family: var(--tealdoc-font-mono);
     line-height: 1.55;
+}
+
+/* The block's padding is the pre's, once. Pico pads the inner code as well,
+ * which doubles it and leaves the two halves impossible to tune apart. */
+.tealdoc-content pre > code {
+    padding: 0;
 }
 
 .tealdoc-content code[class*="language-"] {
@@ -180,22 +186,18 @@ return [[
 }
 
 .tealdoc-content :not(pre) > code {
-    padding: 0;
-    background: transparent;
+    padding: var(--tealdoc-inline-code-padding);
+    border-radius: var(--tealdoc-inline-code-radius);
+    background: var(--tealdoc-inline-code-background);
     font-size: var(--tealdoc-inline-code-font-size);
     font-weight: 550;
 }
 
-.tealdoc-content
-    :not(pre)
-    > code.tealdoc-inline-code-before {
-    padding-inline-start: var(--tealdoc-inline-code-padding);
-}
-
-.tealdoc-content
-    :not(pre)
-    > code.tealdoc-inline-code-after {
-    padding-inline-end: var(--tealdoc-inline-code-padding);
+.tealdoc-content :is(h1, h2, h3, h4, h5, h6) code {
+    padding: 0;
+    background: transparent;
+    font-size: 1em;
+    font-weight: inherit;
 }
 
 .tealdoc-content a > code {

--- a/src/tealdoc/generator/site/css/home.tl
+++ b/src/tealdoc/generator/site/css/home.tl
@@ -24,7 +24,7 @@ return [[
     max-width: 720px;
     margin: 0;
     color: var(--tealdoc-accent);
-    font-size: clamp(3rem, 7vw, 5.5rem);
+    font-size: var(--tealdoc-hero-name-size);
     letter-spacing: -0.04em;
     line-height: 0.95;
 }
@@ -33,7 +33,7 @@ return [[
     max-width: 650px;
     margin: 1.5rem 0 0;
     color: var(--tealdoc-text-muted);
-    font-size: clamp(1.3rem, 2.5vw, 2rem);
+    font-size: var(--tealdoc-hero-text-size);
     line-height: 1.35;
 }
 

--- a/src/tealdoc/generator/site/css/navigation.tl
+++ b/src/tealdoc/generator/site/css/navigation.tl
@@ -23,13 +23,14 @@ return [[
 .tealdoc-sidebar {
     padding: 1.25rem 1rem 2rem;
     border-right: 1px solid var(--tealdoc-border);
-    background: var(--tealdoc-background-alt);
-    box-shadow: -100vw 0 0 100vw var(--tealdoc-background-alt);
+    background: var(--tealdoc-sidebar-background);
+    box-shadow: -100vw 0 0 100vw var(--tealdoc-sidebar-background);
 }
 
 .tealdoc-outline-title {
     margin: 0 0 0.75rem;
     color: var(--tealdoc-text-muted);
+    font-family: var(--tealdoc-outline-font-family);
     font-size: 0.66rem;
     font-weight: 600;
 }
@@ -51,6 +52,7 @@ return [[
     padding: var(--tealdoc-sidebar-item-padding);
     color: var(--tealdoc-sidebar-item-color);
     border-radius: 6px;
+    font-family: var(--tealdoc-sidebar-font-family);
     font-size: var(--tealdoc-sidebar-font-size);
     font-weight: var(--tealdoc-sidebar-font-weight);
     line-height: 1.3;
@@ -65,13 +67,21 @@ return [[
 .tealdoc-sidebar a[aria-current="page"] {
     color: var(--tealdoc-accent);
     background: transparent;
-    font-weight: var(--tealdoc-sidebar-font-weight);
+    font-weight: var(--tealdoc-sidebar-active-font-weight);
 }
 
 .tealdoc-sidebar li.tealdoc-sidebar-section {
     margin-top: var(--tealdoc-sidebar-section-gap) !important;
     padding-top: var(--tealdoc-sidebar-section-padding);
     border-top: 1px solid var(--tealdoc-sidebar-section-border);
+}
+
+/* The first section opens the sidebar, so it carries neither the rule that
+ * separates one group from the last nor the space that rule needs. */
+.tealdoc-sidebar li.tealdoc-sidebar-section:first-child {
+    margin-top: 0 !important;
+    padding-top: 0;
+    border-top: 0;
 }
 
 .tealdoc-sidebar-section details {
@@ -87,6 +97,7 @@ return [[
     padding: 0.22rem 1.2rem 0 0.55rem;
     color: var(--tealdoc-sidebar-heading-color);
     cursor: pointer;
+    font-family: var(--tealdoc-sidebar-font-family);
     font-size: var(--tealdoc-sidebar-heading-font-size);
     font-weight: var(--tealdoc-sidebar-heading-font-weight);
     list-style: none;
@@ -117,7 +128,8 @@ return [[
 
 .tealdoc-sidebar-section ul {
     margin: 0;
-    padding: var(--tealdoc-sidebar-nested-top-padding) 0 0;
+    padding: var(--tealdoc-sidebar-nested-top-padding) 0 0
+        var(--tealdoc-sidebar-nested-indent);
     border-left: 0;
 }
 
@@ -140,19 +152,24 @@ return [[
     padding: 0;
 }
 
+/* A heading that does not fit wraps rather than being cut off: the outline is
+ * a reader's map of the page, and half a title is not one. Two lines is the
+ * limit, after which the rest is elided. */
 .tealdoc-outline a {
     position: relative;
-    display: block;
+    display: -webkit-box;
     overflow: hidden;
     padding: var(--tealdoc-outline-item-padding);
     color: var(--tealdoc-text-muted);
+    font-family: var(--tealdoc-outline-font-family);
     font-size: var(--tealdoc-outline-font-size);
     font-weight: var(--tealdoc-outline-font-weight);
-    line-height: 1.25;
+    line-height: 1.3;
     text-decoration: none;
     text-overflow: ellipsis;
     transition: color 120ms ease;
-    white-space: nowrap;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
 }
 
 .tealdoc-outline a:hover,
@@ -174,7 +191,7 @@ return [[
 .tealdoc-outline .level-3 a {
     padding-left: 0.75rem;
     color: var(--tealdoc-text-faint);
-    font-size: 0.61rem;
+    font-size: var(--tealdoc-outline-nested-font-size);
 }
 
 .tealdoc-outline .level-3 a:hover,

--- a/src/tealdoc/generator/site/css/responsive.tl
+++ b/src/tealdoc/generator/site/css/responsive.tl
@@ -170,7 +170,7 @@ return [[
     }
 
     .tealdoc-hero-copy h1 {
-        font-size: clamp(2.8rem, 14vw, 4.5rem);
+        font-size: var(--tealdoc-hero-name-size-narrow);
     }
 
     .tealdoc-hero-image {

--- a/src/tealdoc/generator/site/css/tokens.tl
+++ b/src/tealdoc/generator/site/css/tokens.tl
@@ -15,6 +15,7 @@ return [[
     --tealdoc-light-text: var(--vp-c-text-1, #213547);
     --tealdoc-light-text-muted: var(--vp-c-text-2, #67676c);
     --tealdoc-light-text-faint: var(--vp-c-text-3, #929295);
+    --tealdoc-light-sidebar-background: var(--tealdoc-light-background-alt);
     --tealdoc-dark-accent: var(--vp-c-brand-1, #5ad9e0);
     --tealdoc-dark-accent-contrast: #102f33;
     --tealdoc-dark-accent-hover: var(--vp-c-brand-2, #7ce4e9);
@@ -29,6 +30,7 @@ return [[
     --tealdoc-dark-text: var(--vp-c-text-1, #dfdfd6);
     --tealdoc-dark-text-muted: var(--vp-c-text-2, #a8a8a3);
     --tealdoc-dark-text-faint: var(--vp-c-text-3, #6a6a71);
+    --tealdoc-dark-sidebar-background: var(--tealdoc-dark-background-alt);
     --tealdoc-accent: var(--tealdoc-light-accent);
     --tealdoc-accent-contrast: var(--tealdoc-light-accent-contrast);
     --tealdoc-accent-hover: var(--tealdoc-light-accent-hover);
@@ -47,8 +49,11 @@ return [[
     --tealdoc-code-background: var(--tealdoc-light-code-background);
     --tealdoc-code-block-font-size: 0.8rem;
     --tealdoc-code-block-radius: 8px;
+    --tealdoc-code-block-padding: 0.8rem 0.9rem;
     --tealdoc-inline-code-font-size: 0.91em;
-    --tealdoc-inline-code-padding: 0.12rem;
+    --tealdoc-inline-code-padding: 0.1em 0.35em;
+    --tealdoc-inline-code-radius: 4px;
+    --tealdoc-inline-code-background: var(--tealdoc-code-background);
     --tealdoc-content-font-size: 0.8rem;
     --tealdoc-content-gutter: 5rem;
     --tealdoc-content-padding-top: 1.25rem;
@@ -89,29 +94,47 @@ return [[
         monospace
     );
     --tealdoc-header-height: var(--vp-nav-height, 64px);
+    --tealdoc-header-background: color-mix(
+        in srgb,
+        var(--tealdoc-background) 92%,
+        transparent
+    );
+    --tealdoc-header-color: var(--tealdoc-text);
+    --tealdoc-header-muted-color: var(--tealdoc-text-muted);
+    --tealdoc-header-border: var(--tealdoc-border);
+    --tealdoc-header-control-background: var(--tealdoc-background-alt);
+    --tealdoc-sidebar-background: var(--tealdoc-light-sidebar-background);
+    --tealdoc-sidebar-font-family: var(--tealdoc-font);
+    --tealdoc-outline-font-family: var(--tealdoc-font);
     --tealdoc-layout-max-width: var(--vp-layout-max-width, 1480px);
     --tealdoc-content-width: var(--vp-content-width, 688px);
     --tealdoc-sidebar-width: var(--vp-sidebar-width, 272px);
     --tealdoc-outline-width: var(--vp-aside-width, 256px);
-    --tealdoc-sidebar-font-size: 0.64rem;
-    --tealdoc-sidebar-font-weight: 700;
-    --tealdoc-sidebar-item-padding: 0.22rem 0.55rem;
+    --tealdoc-sidebar-font-size: 0.7rem;
+    --tealdoc-sidebar-font-weight: 500;
+    --tealdoc-sidebar-active-font-weight: 600;
+    --tealdoc-sidebar-item-padding: 0.24rem 0.55rem;
     --tealdoc-sidebar-item-color: var(--tealdoc-text-muted);
     --tealdoc-sidebar-heading-color: var(--tealdoc-text);
-    --tealdoc-sidebar-heading-font-size: 0.66rem;
+    --tealdoc-sidebar-heading-font-size: 0.7rem;
     --tealdoc-sidebar-heading-font-weight: 700;
     --tealdoc-sidebar-section-border: var(--tealdoc-border);
-    --tealdoc-sidebar-section-gap: 1.9rem;
-    --tealdoc-sidebar-section-padding: 2.3rem;
-    --tealdoc-sidebar-nested-top-padding: 6px;
-    --tealdoc-outline-font-size: 0.64rem;
+    --tealdoc-sidebar-section-gap: 1.1rem;
+    --tealdoc-sidebar-section-padding: 1.1rem;
+    --tealdoc-sidebar-nested-top-padding: 4px;
+    --tealdoc-sidebar-nested-indent: 0.5rem;
+    --tealdoc-outline-font-size: 0.66rem;
     --tealdoc-outline-font-weight: 600;
     --tealdoc-outline-item-padding: 0.16rem 0;
+    --tealdoc-outline-nested-font-size: 0.61rem;
     --tealdoc-hero-glow-color: var(--tealdoc-accent);
     --tealdoc-hero-glow-size: min(46vw, 520px);
     --tealdoc-hero-glow-blur: 24px;
     --tealdoc-hero-glow-opacity: 0.68;
     --tealdoc-hero-features-gap: 2rem;
+    --tealdoc-hero-name-size: clamp(3rem, 7vw, 5.5rem);
+    --tealdoc-hero-text-size: clamp(1.3rem, 2.5vw, 2rem);
+    --tealdoc-hero-name-size-narrow: clamp(2.8rem, 14vw, 4.5rem);
     --tealdoc-home-width: 1152px;
     --tealdoc-home-gutter: 2rem;
     --tealdoc-button-brand-background: var(--tealdoc-accent);
@@ -164,6 +187,7 @@ return [[
         );
         --tealdoc-background: var(--tealdoc-dark-background);
         --tealdoc-background-alt: var(--tealdoc-dark-background-alt);
+        --tealdoc-sidebar-background: var(--tealdoc-dark-sidebar-background);
         --tealdoc-background-elv: var(--tealdoc-dark-background-elv);
         --tealdoc-border: var(--tealdoc-dark-border);
         --tealdoc-code-background: var(--tealdoc-dark-code-background);
@@ -201,6 +225,7 @@ return [[
     );
     --tealdoc-background: var(--tealdoc-dark-background);
     --tealdoc-background-alt: var(--tealdoc-dark-background-alt);
+    --tealdoc-sidebar-background: var(--tealdoc-dark-sidebar-background);
     --tealdoc-background-elv: var(--tealdoc-dark-background-elv);
     --tealdoc-border: var(--tealdoc-dark-border);
     --tealdoc-code-background: var(--tealdoc-dark-code-background);
@@ -238,6 +263,7 @@ return [[
         );
         --tealdoc-background: var(--tealdoc-light-background);
         --tealdoc-background-alt: var(--tealdoc-light-background-alt);
+        --tealdoc-sidebar-background: var(--tealdoc-light-sidebar-background);
         --tealdoc-background-elv: var(--tealdoc-light-background-elv);
         --tealdoc-border: var(--tealdoc-light-border);
         --tealdoc-code-background: var(--tealdoc-light-code-background);

--- a/src/tealdoc/generator/site/markdown.tl
+++ b/src/tealdoc/generator/site/markdown.tl
@@ -10,7 +10,6 @@ local record SiteMarkdown
 end
 
 local escape_html = Text.escape_html
-local strip_tags = Text.strip_tags
 
 local admonition_kinds: {string: string} = {
     ["danger"] = "Danger",
@@ -143,59 +142,6 @@ local function site_blockquote(content: any): any
             "</p>",
         body,
         "</aside>",
-    }
-end
-
-local function mark_inline_code_spacing(rendered: string): string
-    local output: {string} = {}
-    local position = 1
-    while true do
-        local opening_start, opening_end = rendered:find(
-            "<code>",
-            position,
-            true
-        )
-        if not opening_start then
-            table.insert(output, rendered:sub(position))
-            break
-        end
-        local closing_start, closing_end = rendered:find(
-            "</code>",
-            opening_end + 1,
-            true
-        )
-        if not closing_start then
-            table.insert(output, rendered:sub(position))
-            break
-        end
-
-        table.insert(output, rendered:sub(position, opening_start - 1))
-        local classes: {string} = {}
-        if strip_tags(rendered:sub(1, opening_start - 1)):match("%S") then
-            table.insert(classes, "tealdoc-inline-code-before")
-        end
-        if strip_tags(rendered:sub(closing_end + 1)):match("%S") then
-            table.insert(classes, "tealdoc-inline-code-after")
-        end
-        if #classes > 0 then
-            table.insert(
-                output,
-                '<code class="' .. table.concat(classes, " ") .. '">'
-            )
-        else
-            table.insert(output, "<code>")
-        end
-        table.insert(output, rendered:sub(opening_end + 1, closing_end))
-        position = closing_end + 1
-    end
-    return table.concat(output)
-end
-
-local function site_paragraph(content: any): any
-    return {
-        "<p>",
-        mark_inline_code_spacing(rope_to_string(content)),
-        "</p>",
     }
 end
 
@@ -333,10 +279,12 @@ function SiteMarkdown.render(
                 ">",
             }
         end,
-        paragraph = site_paragraph,
     })
     builder:md(markdown)
     local html = builder:build()
+    -- A fence carries a newline before its closing line, and a browser renders
+    -- that as a blank last line inside the block. Nobody wrote it, so it goes.
+    html = html:gsub("\n+(</code></pre>)", "%1")
     local function highlight_code(
         language: string,
         links?: Highlighter.Links

--- a/tlconfig.lua
+++ b/tlconfig.lua
@@ -4,5 +4,75 @@ return {
     include_dir = {
         "src",
         "types"
-    }
+    },
+
+    -- The site this project publishes, and the worked example of a
+    -- configuration. It sets a title, a description and its pages, and
+    -- nothing else: no custom stylesheet, no template override, no theme
+    -- settings. What it looks like is what the defaults look like, which is
+    -- the point of keeping it this short.
+    tealdoc = {
+        site = {
+            title = "Tealdoc",
+            description = "A documentation generator for Teal",
+            base = "/",
+            sources = { "src/tealdoc.tl" },
+            nav = {
+                { text = "Install", path = "installation" },
+                { text = "Tutorial", path = "tutorial" },
+                { text = "API", path = "api" },
+            },
+            pages = {
+                {
+                    path = "",
+                    title = "Tealdoc",
+                    description = "A documentation generator for Teal",
+                    source = "docs/header.md",
+                },
+                {
+                    path = "installation",
+                    title = "Installation",
+                    description = "Installing tealdoc with LuaRocks",
+                    source = "docs/installation.md",
+                },
+                {
+                    path = "tutorial",
+                    title = "Tutorial",
+                    description = "How to document your code",
+                    source = "docs/tutorial.md",
+                },
+                {
+                    path = "cli",
+                    title = "CLI reference",
+                    description = "Commands, flags and configuration",
+                    source = "docs/cli_reference.md",
+                },
+                {
+                    path = "site",
+                    title = "Site configuration",
+                    description = "Every tealdoc.site setting",
+                    source = "docs/site_configuration.md",
+                },
+                {
+                    path = "architecture",
+                    title = "Architecture",
+                    description = "How tealdoc is put together",
+                    source = "docs/architecture.md",
+                },
+                {
+                    path = "about",
+                    title = "About",
+                    description = "Where tealdoc came from",
+                    source = "docs/about.md",
+                },
+                {
+                    path = "api",
+                    title = "API",
+                    description = "The tealdoc module",
+                    source = "docs/api_reference_header.md",
+                    api = "tealdoc",
+                },
+            },
+        },
+    },
 }


### PR DESCRIPTION
Follow-up to #25, which added the site generator. This is what I found using it
to build a real site: three layout bugs in the default theme, parameter and
return tables, and this project's own docs published as a site so the defaults
are exercised by something other than the spec suite.

## Layout fixes

Two of these are bugs a user hits without doing anything unusual.

**Code groups rendered as a horizontal row.** Pico styles `[role="group"]` as
`display: inline-flex`, and the group carries that role, so a `::: code-group`
with three blocks put them side by side and overflowed the page. The group now
states its own display.

**An `@import` in a custom stylesheet was silently dropped when the sheet
opened with a comment.** Imports are hoisted to the front of the concatenated
sheet, but the scan stopped at the first comment, so a sheet that began with a
comment lost its `@import` and any font it pulled in. Silent, and it looks like
the font simply does not work.

**The outline made siblings look nested.** The first entry in a group of
members rendered its full name and every later one was abbreviated with an
arrow, because the first sets the prefix in the `else` branch and so never
matches it. Reading `tecs.assets.Batch` / `↳ Handle` / `↳ install`, it is not
clear whether the arrows hang off `Batch` or off the section. The prefix now
comes from the group rather than from its first member, and the arrow is gone.

Also here: inline code had two generated classes driving conditional padding
and no background, which is now plain symmetric padding and a background from a
token; sidebar and outline spacing; a fence's closing newline rendering as a
blank last line; and code blocks padded twice, once by the `pre` and once by
Pico's inner `code`.

New tokens for the header colours, the sidebar surface, a font family per
navigation, the hero type sizes and the code block padding, so a site can
retheme those without writing rules against classes.

## Parameter and return tables

Arguments, returns and type arguments render as tables rather than as a `<ul>`
and an `<ol>`. Columns are Name/Type/Description for parameters,
Type/Description for returns, and Name/Constraint/Description for type
arguments. A return has no name in Teal, so its table starts at the type
instead of carrying an empty column.

This is a port rather than new work: I wrote it before the site generator
existed and it did not survive the rewrite of `default_env.tl`. The builder API
and the columns are the same; what is new is that the Markdown cell writer
escapes a pipe as `&#124;` and promotes a backtick span containing one to a
`<code>` element. lunamark does not honour `\|` inside a table cell, so a union
type such as `string | nil` split across two cells.

## The example site

`tlconfig.lua` now has a `tealdoc.site` block that builds `docs/` into a site.
It is deliberately the shortest configuration that produces a real one: a
title, a description, the pages, and an API page pointed at the module. No
custom stylesheet, no template override, no theme setting, so what it looks
like is what the defaults look like.

## Review notes

The three commits are separable and worth reading in order. The layout commit
touches the CSS modules and `site.tl`'s heading walk; the table commit touches
`default_env.tl`, both builders and the table CSS in two places, since the HTML
generator and the site have separate stylesheets.

## Testing

`make build` leaves `build/` byte-identical to what is committed, so the
generated-diff check is clean. `make test` reports 41 failures both on this
branch and on `main` at `0648d89`, with an identical failing set: they are all
in `spec/parser/teal/*` and come from a `tl` version mismatch in my
environment, not from these changes. `site_spec` and the generator specs pass.

Beyond the suite I built two sites and read them in a browser, light and dark,
at desktop and at 700px: this project's own docs, which is the example above,
and a larger one with about sixty pages. The pipe-escaping bug and the code
group overflow both came from looking rather than from a spec.
