### PR TITLE
Render Markdown without a temp file

### DIFF
--- a/build/tealdoc/generator/markdown.lua
+++ b/build/tealdoc/generator/markdown.lua
@@ -254,6 +254,12 @@ local MarkdownGenerator = {}
 
 
 
+
+
+
+
+
+
 MarkdownGenerator.item_phases = {}
 
 function MarkdownGenerator.resolve_type_url(
@@ -286,8 +292,16 @@ function MarkdownGenerator.resolve_type_url(
    return nil
 end
 
-MarkdownGenerator.init = function(
-   output,
+
+
+
+
+
+
+
+
+
+local function generator_for(
    type_url_for_path,
    allow_local_type_links)
 
@@ -314,6 +328,22 @@ MarkdownGenerator.init = function(
          end
       end
    end
+   return base, builder
+end
+
+
+
+
+
+
+
+
+MarkdownGenerator.init = function(
+   output,
+   type_url_for_path,
+   allow_local_type_links)
+
+   local base, builder = generator_for(type_url_for_path, allow_local_type_links)
    base.on_end = function(_, _)
       local file = io.open(output, "w")
       assert(file, "Could not open file for writing: " .. output)
@@ -322,6 +352,28 @@ MarkdownGenerator.init = function(
       log:info("Markdown documentation generated to " .. output)
    end
    return base
+end
+
+
+
+
+
+
+
+
+
+
+
+
+
+MarkdownGenerator.render = function(
+   env,
+   type_url_for_path,
+   allow_local_type_links)
+
+   local base, builder = generator_for(type_url_for_path, allow_local_type_links)
+   base:run(env)
+   return builder:build()
 end
 
 return MarkdownGenerator

--- a/build/tealdoc/generator/site/api.lua
+++ b/build/tealdoc/generator/site/api.lua
@@ -1,4 +1,4 @@
-local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local io = _tl_compat and _tl_compat.io or io; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local math = _tl_compat and _tl_compat.math or math; local os = _tl_compat and _tl_compat.os or os; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local tealdoc = require("tealdoc")
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local io = _tl_compat and _tl_compat.io or io; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local math = _tl_compat and _tl_compat.math or math; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local tealdoc = require("tealdoc")
 local Generator = require("tealdoc.generator")
 local MarkdownGenerator = require("tealdoc.generator.markdown")
 local Highlighter = require("tealdoc.generator.site.highlighter")
@@ -185,11 +185,10 @@ function SiteApi.markdown(
 
    local page_env = view.env
 
-   local output = os.tmpname()
-   MarkdownGenerator.init(output, resolver, false):run(page_env)
-   local markdown = read_file(output)
-   os.remove(output)
-   markdown = add_kind_badges(markdown, page_env)
+   local markdown = add_kind_badges(
+   MarkdownGenerator.render(page_env, resolver, false),
+   page_env)
+
 
    for item_path, examples in pairs(attached_examples or {}) do
       local anchor = '<a id="' .. item_path .. '"></a>'

--- a/src/tealdoc/generator/markdown.tl
+++ b/src/tealdoc/generator/markdown.tl
@@ -245,6 +245,12 @@ local record MarkdownGenerator
         type_url_for_path?: URLResolver,
         allow_local_type_links?: boolean
     ): Generator.Base
+    --- Renders documentation and answers with it rather than writing a file.
+    render: function(
+        env: tealdoc.Env,
+        type_url_for_path?: URLResolver,
+        allow_local_type_links?: boolean
+    ): string
     resolve_type_url: function(
         env: tealdoc.Env,
         path: string,
@@ -286,11 +292,19 @@ function MarkdownGenerator.resolve_type_url(
     return nil
 end
 
-MarkdownGenerator.init = function(
-    output: string,
+--- Builds a generator and hands back the builder it writes into.
+---
+--- Shared by `init`, which writes the result to a file, and `render`, which
+--- answers with it. The two differ only in what happens once the walk is done.
+--- @param type_url_for_path Resolves a type's path to a URL, or nil to leave
+---     types unlinked.
+--- @param allow_local_type_links Whether a type may link to an anchor on the
+---     page being rendered.
+--- @return The generator, and the builder holding what it wrote.
+local function generator_for(
     type_url_for_path?: MarkdownGenerator.URLResolver,
     allow_local_type_links?: boolean
-): Generator.Base
+): Generator.Base, MarkdownBuilder
     local builder = MarkdownBuilder.init()
     local base = Generator.Base.init()
     base.item_phases = MarkdownGenerator.item_phases
@@ -314,6 +328,22 @@ MarkdownGenerator.init = function(
             end
         end
     end
+    return base, builder
+end
+
+--- Renders documentation to a file.
+--- @param output The path written when the walk ends.
+--- @param type_url_for_path Resolves a type's path to a URL, or nil to leave
+---     types unlinked.
+--- @param allow_local_type_links Whether a type may link to an anchor on the
+---     page being rendered.
+--- @return A generator that writes `output` when it finishes.
+MarkdownGenerator.init = function(
+    output: string,
+    type_url_for_path?: MarkdownGenerator.URLResolver,
+    allow_local_type_links?: boolean
+): Generator.Base
+    local base, builder = generator_for(type_url_for_path, allow_local_type_links)
     base.on_end = function(_, _: tealdoc.Env)
         local file = io.open(output, "w")
         assert(file, "Could not open file for writing: " .. output)
@@ -322,6 +352,28 @@ MarkdownGenerator.init = function(
         log:info("Markdown documentation generated to " .. output)
     end
     return base
+end
+
+--- Renders documentation and answers with it.
+---
+--- The site generator composes a page from Markdown it renders here, so it
+--- wants the text rather than a file. Writing one to read it back costs a
+--- temporary file per API page, and the caller then has to remove it, which a
+--- raised error skips.
+--- @param env The environment to walk.
+--- @param type_url_for_path Resolves a type's path to a URL, or nil to leave
+---     types unlinked.
+--- @param allow_local_type_links Whether a type may link to an anchor on the
+---     page being rendered.
+--- @return The rendered Markdown.
+MarkdownGenerator.render = function(
+    env: tealdoc.Env,
+    type_url_for_path?: MarkdownGenerator.URLResolver,
+    allow_local_type_links?: boolean
+): string
+    local base, builder = generator_for(type_url_for_path, allow_local_type_links)
+    base:run(env)
+    return builder:build()
 end
 
 return MarkdownGenerator

--- a/src/tealdoc/generator/site/api.tl
+++ b/src/tealdoc/generator/site/api.tl
@@ -185,11 +185,10 @@ function SiteApi.markdown(
 
     local page_env = view.env
 
-    local output = os.tmpname()
-    MarkdownGenerator.init(output, resolver, false):run(page_env)
-    local markdown = read_file(output)
-    os.remove(output)
-    markdown = add_kind_badges(markdown, page_env)
+    local markdown = add_kind_badges(
+        MarkdownGenerator.render(page_env, resolver, false),
+        page_env
+    )
 
     for item_path, examples in pairs(attached_examples or {}) do
         local anchor = '<a id="' .. item_path .. '"></a>'


### PR DESCRIPTION
The Markdown builder already holds the finished string, but the site
generator could only get it by writing a file and reading it back, so a
site with thirty API pages wrote and removed thirty temp files.

`MarkdownGenerator.render` answers with the string. `init` still writes,
for callers that want a file, and the two share the walk.

Not a speedup. I measured a thirty-page site before and after and it
builds in the same time; the cost is type-checking the modules, not the
file I/O. What it fixes is a temp file per page that an error between
the write and the remove leaves behind, and a call site that no longer
handles a file it never wanted.

`make test` is unchanged at 41 failures, same set as main, all in the
Teal parser specs from a `tl` version mismatch here.