### PR TITLE
Size the hero in rem and anchor it to the top

### DIFF
--- a/build/tealdoc/generator/site/css/home.lua
+++ b/build/tealdoc/generator/site/css/home.lua
@@ -3,10 +3,13 @@ return [[
     margin: 0 0 4rem;
 }
 
+/* The row is as tall as what is in it, and the copy is anchored to the top of
+ * it. Centering the copy inside a row with a floor put space above the heading
+ * whenever the copy came up short of that floor, and the narrower the window
+ * the shorter the copy and the more of it there was. */
 .tealdoc-hero-main {
     display: grid;
-    min-height: 360px;
-    align-items: center;
+    align-items: start;
     gap: 3rem;
     grid-template-columns: minmax(0, 1fr);
 }
@@ -19,6 +22,7 @@ return [[
     position: relative;
     z-index: 1;
 }
+
 
 .tealdoc-hero-copy h1 {
     max-width: 720px;
@@ -79,10 +83,12 @@ return [[
     background: var(--tealdoc-button-alt-hover-background);
 }
 
+/* The image is the one thing that centers, against whichever column is taller. */
 .tealdoc-hero-image {
     position: relative;
     display: grid;
     min-height: 340px;
+    align-self: center;
     place-items: center;
     transform: translateY(-12px);
 }

--- a/build/tealdoc/generator/site/css/responsive.lua
+++ b/build/tealdoc/generator/site/css/responsive.lua
@@ -165,12 +165,15 @@ return [[
     }
 
     .tealdoc-hero-main {
-        min-height: 0;
         gap: 2rem;
     }
 
     .tealdoc-hero-copy h1 {
         font-size: var(--tealdoc-hero-name-size-narrow);
+    }
+
+    .tealdoc-hero-text {
+        font-size: var(--tealdoc-hero-text-size-narrow);
     }
 
     .tealdoc-hero-image {

--- a/build/tealdoc/generator/site/css/tokens.lua
+++ b/build/tealdoc/generator/site/css/tokens.lua
@@ -128,13 +128,19 @@ return [[
     --tealdoc-outline-item-padding: 0.16rem 0;
     --tealdoc-outline-nested-font-size: 0.61rem;
     --tealdoc-hero-glow-color: var(--tealdoc-accent);
-    --tealdoc-hero-glow-size: min(46vw, 520px);
+    --tealdoc-hero-glow-size: 520px;
     --tealdoc-hero-glow-blur: 24px;
     --tealdoc-hero-glow-opacity: 0.68;
     --tealdoc-hero-features-gap: 2rem;
-    --tealdoc-hero-name-size: clamp(3rem, 7vw, 5.5rem);
-    --tealdoc-hero-text-size: clamp(1.3rem, 2.5vw, 2rem);
-    --tealdoc-hero-name-size-narrow: clamp(2.8rem, 14vw, 4.5rem);
+    /* The hero is sized in rem and steps at the breakpoints below, rather than
+     * sliding with `vw`. Browser zoom is a change in the viewport, so a `vw`
+     * size resizes against the zoom instead of with it: the reader asks for a
+     * larger page and the heading and the line under it come apart. A rem
+     * scales by exactly the zoom factor, which is what was asked for. */
+    --tealdoc-hero-name-size: 5.5rem;
+    --tealdoc-hero-text-size: 2rem;
+    --tealdoc-hero-name-size-narrow: 4rem;
+    --tealdoc-hero-text-size-narrow: 1.5rem;
     --tealdoc-home-width: 1152px;
     --tealdoc-home-gutter: 2rem;
     --tealdoc-button-brand-background: var(--tealdoc-accent);

--- a/src/tealdoc/generator/site/css/home.tl
+++ b/src/tealdoc/generator/site/css/home.tl
@@ -3,10 +3,13 @@ return [[
     margin: 0 0 4rem;
 }
 
+/* The row is as tall as what is in it, and the copy is anchored to the top of
+ * it. Centering the copy inside a row with a floor put space above the heading
+ * whenever the copy came up short of that floor, and the narrower the window
+ * the shorter the copy and the more of it there was. */
 .tealdoc-hero-main {
     display: grid;
-    min-height: 360px;
-    align-items: center;
+    align-items: start;
     gap: 3rem;
     grid-template-columns: minmax(0, 1fr);
 }
@@ -19,6 +22,7 @@ return [[
     position: relative;
     z-index: 1;
 }
+
 
 .tealdoc-hero-copy h1 {
     max-width: 720px;
@@ -79,10 +83,12 @@ return [[
     background: var(--tealdoc-button-alt-hover-background);
 }
 
+/* The image is the one thing that centers, against whichever column is taller. */
 .tealdoc-hero-image {
     position: relative;
     display: grid;
     min-height: 340px;
+    align-self: center;
     place-items: center;
     transform: translateY(-12px);
 }

--- a/src/tealdoc/generator/site/css/responsive.tl
+++ b/src/tealdoc/generator/site/css/responsive.tl
@@ -165,12 +165,15 @@ return [[
     }
 
     .tealdoc-hero-main {
-        min-height: 0;
         gap: 2rem;
     }
 
     .tealdoc-hero-copy h1 {
         font-size: var(--tealdoc-hero-name-size-narrow);
+    }
+
+    .tealdoc-hero-text {
+        font-size: var(--tealdoc-hero-text-size-narrow);
     }
 
     .tealdoc-hero-image {

--- a/src/tealdoc/generator/site/css/tokens.tl
+++ b/src/tealdoc/generator/site/css/tokens.tl
@@ -128,13 +128,19 @@ return [[
     --tealdoc-outline-item-padding: 0.16rem 0;
     --tealdoc-outline-nested-font-size: 0.61rem;
     --tealdoc-hero-glow-color: var(--tealdoc-accent);
-    --tealdoc-hero-glow-size: min(46vw, 520px);
+    --tealdoc-hero-glow-size: 520px;
     --tealdoc-hero-glow-blur: 24px;
     --tealdoc-hero-glow-opacity: 0.68;
     --tealdoc-hero-features-gap: 2rem;
-    --tealdoc-hero-name-size: clamp(3rem, 7vw, 5.5rem);
-    --tealdoc-hero-text-size: clamp(1.3rem, 2.5vw, 2rem);
-    --tealdoc-hero-name-size-narrow: clamp(2.8rem, 14vw, 4.5rem);
+    /* The hero is sized in rem and steps at the breakpoints below, rather than
+     * sliding with `vw`. Browser zoom is a change in the viewport, so a `vw`
+     * size resizes against the zoom instead of with it: the reader asks for a
+     * larger page and the heading and the line under it come apart. A rem
+     * scales by exactly the zoom factor, which is what was asked for. */
+    --tealdoc-hero-name-size: 5.5rem;
+    --tealdoc-hero-text-size: 2rem;
+    --tealdoc-hero-name-size-narrow: 4rem;
+    --tealdoc-hero-text-size-narrow: 1.5rem;
     --tealdoc-home-width: 1152px;
     --tealdoc-home-gutter: 2rem;
     --tealdoc-button-brand-background: var(--tealdoc-accent);


### PR DESCRIPTION
The hero was sized in `vw` and centered in a row with a 360px floor. Zoom changes the viewport, so `vw` type resized against the zoom instead of with it, and the centering put space above the heading whenever the copy came up short: 3px at 1920, 40px at 900.

Now rem, stepping once at the 760px breakpoint. No horizontal overflow down to 375px.