### PR TITLE
Claim the sidebar heading color back from Pico

### DIFF
--- a/build/tealdoc/generator/site/css/navigation.lua
+++ b/build/tealdoc/generator/site/css/navigation.lua
@@ -95,12 +95,21 @@ return [[
     position: relative;
     margin: 0;
     padding: 0.22rem 1.2rem 0 0.55rem;
-    color: var(--tealdoc-sidebar-heading-color);
     cursor: pointer;
     font-family: var(--tealdoc-sidebar-font-family);
     font-size: var(--tealdoc-sidebar-heading-font-size);
     font-weight: var(--tealdoc-sidebar-heading-font-weight);
     list-style: none;
+}
+
+/* Pico colors an accordion summary through
+ * `details[open] > summary:not([role]):not(:focus)`, and a class and an
+ * element name do not outweigh that, so the theme's own color has to be
+ * claimed at the same specificity or the heading is Pico's slate on every
+ * site. Both states, because the closed one is out-specified too. */
+.tealdoc-sidebar-section details > summary:not([role]),
+.tealdoc-sidebar-section details[open] > summary:not([role]) {
+    color: var(--tealdoc-sidebar-heading-color);
 }
 
 .tealdoc-sidebar-section details[open] > summary {

--- a/src/tealdoc/generator/site/css/navigation.tl
+++ b/src/tealdoc/generator/site/css/navigation.tl
@@ -95,12 +95,21 @@ return [[
     position: relative;
     margin: 0;
     padding: 0.22rem 1.2rem 0 0.55rem;
-    color: var(--tealdoc-sidebar-heading-color);
     cursor: pointer;
     font-family: var(--tealdoc-sidebar-font-family);
     font-size: var(--tealdoc-sidebar-heading-font-size);
     font-weight: var(--tealdoc-sidebar-heading-font-weight);
     list-style: none;
+}
+
+/* Pico colors an accordion summary through
+ * `details[open] > summary:not([role]):not(:focus)`, and a class and an
+ * element name do not outweigh that, so the theme's own color has to be
+ * claimed at the same specificity or the heading is Pico's slate on every
+ * site. Both states, because the closed one is out-specified too. */
+.tealdoc-sidebar-section details > summary:not([role]),
+.tealdoc-sidebar-section details[open] > summary:not([role]) {
+    color: var(--tealdoc-sidebar-heading-color);
 }
 
 .tealdoc-sidebar-section details[open] > summary {


### PR DESCRIPTION
Pico colors an open accordion summary through `details[open]>summary:not([role]):not(:focus)`, which a class plus an element name does not outweigh. Every site's sidebar headings rendered in Pico's slate instead of `--tealdoc-sidebar-heading-color`. Closed sections were out-specified too, so both states are claimed.