### PR TITLE
Repaint the theme on the root, not the tree under it

### DIFF
--- a/build/tealdoc/generator/site/css/tokens.lua
+++ b/build/tealdoc/generator/site/css/tokens.lua
@@ -216,7 +216,15 @@ return [[
     }
 }
 
-.tealdoc-theme-input:checked ~ .tealdoc-site {
+/* The toggle repaints the root, not the tree under it, because a custom
+ * property resolves where it is declared. Half the tokens above are declared
+ * here as indirections onto the theme colors, so a repaint applied to a
+ * descendant reaches the ones a rule reads directly and none of the ones read
+ * through an indirection: those keep whatever the root resolved them to, and
+ * the theme the reader asked for arrives in pieces. Repainting the root itself
+ * resolves them all at once, and a site's own `:root` values still cascade
+ * against the primitives the same way. */
+:root:has(.tealdoc-theme-input:checked) {
     color-scheme: dark;
     --tealdoc-accent: var(--tealdoc-dark-accent);
     --tealdoc-accent-contrast: var(--tealdoc-dark-accent-contrast);
@@ -254,7 +262,7 @@ return [[
 }
 
 @media (prefers-color-scheme: dark) {
-    .tealdoc-theme-input:checked ~ .tealdoc-site {
+    :root:has(.tealdoc-theme-input:checked) {
         color-scheme: light;
         --tealdoc-accent: var(--tealdoc-light-accent);
         --tealdoc-accent-contrast: var(--tealdoc-light-accent-contrast);

--- a/src/tealdoc/generator/site/css/tokens.tl
+++ b/src/tealdoc/generator/site/css/tokens.tl
@@ -216,7 +216,15 @@ return [[
     }
 }
 
-.tealdoc-theme-input:checked ~ .tealdoc-site {
+/* The toggle repaints the root, not the tree under it, because a custom
+ * property resolves where it is declared. Half the tokens above are declared
+ * here as indirections onto the theme colors, so a repaint applied to a
+ * descendant reaches the ones a rule reads directly and none of the ones read
+ * through an indirection: those keep whatever the root resolved them to, and
+ * the theme the reader asked for arrives in pieces. Repainting the root itself
+ * resolves them all at once, and a site's own `:root` values still cascade
+ * against the primitives the same way. */
+:root:has(.tealdoc-theme-input:checked) {
     color-scheme: dark;
     --tealdoc-accent: var(--tealdoc-dark-accent);
     --tealdoc-accent-contrast: var(--tealdoc-dark-accent-contrast);
@@ -254,7 +262,7 @@ return [[
 }
 
 @media (prefers-color-scheme: dark) {
-    .tealdoc-theme-input:checked ~ .tealdoc-site {
+    :root:has(.tealdoc-theme-input:checked) {
         color-scheme: light;
         --tealdoc-accent: var(--tealdoc-light-accent);
         --tealdoc-accent-contrast: var(--tealdoc-light-accent-contrast);


### PR DESCRIPTION
A custom property resolves where it is declared. About sixteen tokens are declared at `:root` as indirections onto the theme colors (`--tealdoc-sidebar-item-color: var(--tealdoc-text-muted)`), so a repaint applied to `.tealdoc-site` never reached them: they kept whatever the root resolved them to.

Light mode arrived in pieces. Measured on the toggle, before and after:

| Token | Before | After |
| --- | --- | --- |
| `--tealdoc-sidebar-item-color` | `#b6ad9e` | `#565047` |
| `--tealdoc-sidebar-heading-color` | `#d9d2c3` | `#302d29` |
| `--tealdoc-footer-text` | `#8f8677` | `#756d60` |
| `--tealdoc-button-brand-background` | `#a192b1` | `#372455` |

Sidebar text washed out and inline code rendered as dark chips on a light page. Repainting `:root` itself resolves them all at once. A site's own `:root` overrides still win, verified against one that sets `--tealdoc-header-color`.

Needs `:has()`, baseline since late 2023.