### PR TITLE
Read a nested group in the color of its siblings

### DIFF
--- a/build/tealdoc/generator/site/css/navigation.lua
+++ b/build/tealdoc/generator/site/css/navigation.lua
@@ -120,6 +120,13 @@ return [[
     color: var(--tealdoc-sidebar-heading-color);
 }
 
+/* A group nested inside another is one row among the rows it sits with, so it
+ * reads in their color. The heading color belongs to the top level, which is
+ * what the rule and the space above it already divide. */
+.tealdoc-sidebar-section .tealdoc-sidebar-section > details > summary:not([role]) {
+    color: var(--tealdoc-sidebar-item-color);
+}
+
 .tealdoc-sidebar-section details[open] > summary {
     margin-bottom: 0;
 }

--- a/src/tealdoc/generator/site/css/navigation.tl
+++ b/src/tealdoc/generator/site/css/navigation.tl
@@ -120,6 +120,13 @@ return [[
     color: var(--tealdoc-sidebar-heading-color);
 }
 
+/* A group nested inside another is one row among the rows it sits with, so it
+ * reads in their color. The heading color belongs to the top level, which is
+ * what the rule and the space above it already divide. */
+.tealdoc-sidebar-section .tealdoc-sidebar-section > details > summary:not([role]) {
+    color: var(--tealdoc-sidebar-item-color);
+}
+
 .tealdoc-sidebar-section details[open] > summary {
     margin-bottom: 0;
 }


### PR DESCRIPTION
A nested group's heading took the top-level heading color, so it read stronger than the rows it sits among. It now takes the item color; the heading color belongs to the top level, which the rule and the space above it already divide.