### PR TITLE
Let the hero image sit level with the heading

### DIFF
--- a/build/tealdoc/generator/site/css/home.lua
+++ b/build/tealdoc/generator/site/css/home.lua
@@ -83,14 +83,15 @@ return [[
     background: var(--tealdoc-button-alt-hover-background);
 }
 
-/* The image is the one thing that centers, against whichever column is taller. */
+/* The image is the one thing that centers, against whichever column is taller.
+ * It carries no floor of its own: a floor taller than the image only pushes
+ * the image down the middle of it and away from the heading it sits beside,
+ * and the row is already as tall as the taller of the two columns. */
 .tealdoc-hero-image {
     position: relative;
     display: grid;
-    min-height: 340px;
     align-self: center;
     place-items: center;
-    transform: translateY(-12px);
 }
 
 .tealdoc-hero-starburst {

--- a/build/tealdoc/generator/site/css/responsive.lua
+++ b/build/tealdoc/generator/site/css/responsive.lua
@@ -176,10 +176,6 @@ return [[
         font-size: var(--tealdoc-hero-text-size-narrow);
     }
 
-    .tealdoc-hero-image {
-        min-height: 280px;
-    }
-
     .tealdoc-hero-starburst {
         width: min(78vw, 340px);
     }

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -1245,12 +1245,11 @@ print(value)
             true
         ))
         assert.is_truthy(css:find(
-            "transform: translateY(-12px)",
-            1,
-            true
-        ))
-        assert.is_truthy(css:find(
-            ".tealdoc-hero-image {\n    position: relative;\n    display: grid;\n    min-height: 340px;",
+            ".tealdoc-hero-image {\n" ..
+                "    position: relative;\n" ..
+                "    display: grid;\n" ..
+                "    align-self: center;\n" ..
+                "    place-items: center;",
             1,
             true
         ))

--- a/src/tealdoc/generator/site/css/home.tl
+++ b/src/tealdoc/generator/site/css/home.tl
@@ -83,14 +83,15 @@ return [[
     background: var(--tealdoc-button-alt-hover-background);
 }
 
-/* The image is the one thing that centers, against whichever column is taller. */
+/* The image is the one thing that centers, against whichever column is taller.
+ * It carries no floor of its own: a floor taller than the image only pushes
+ * the image down the middle of it and away from the heading it sits beside,
+ * and the row is already as tall as the taller of the two columns. */
 .tealdoc-hero-image {
     position: relative;
     display: grid;
-    min-height: 340px;
     align-self: center;
     place-items: center;
-    transform: translateY(-12px);
 }
 
 .tealdoc-hero-starburst {

--- a/src/tealdoc/generator/site/css/responsive.tl
+++ b/src/tealdoc/generator/site/css/responsive.tl
@@ -176,10 +176,6 @@ return [[
         font-size: var(--tealdoc-hero-text-size-narrow);
     }
 
-    .tealdoc-hero-image {
-        min-height: 280px;
-    }
-
     .tealdoc-hero-starburst {
         width: min(78vw, 340px);
     }


### PR DESCRIPTION
The image box kept a 340px floor from when the row had one. With the row content-sized, that floor was the only thing making it 340 tall, and the image centered inside it 34px below the heading it sits beside. The floor and the -12px nudge that went with it are both gone: the image now tops out level with the heading, and the row is as tall as the taller column.