### PR TITLE
Group the module reference into types, functions and values

### DIFF
--- a/build/tealdoc/generator/site/api.lua
+++ b/build/tealdoc/generator/site/api.lua
@@ -327,10 +327,15 @@ function SiteApi.summary(
 
 
 
+
+
+
+
+
    local groups = {
-      { "Types", "Type", {} },
-      { "Functions", "Function", {} },
-      { "Values", "Value", {} },
+      { "Types", "Type", true, {} },
+      { "Functions", "Function", false, {} },
+      { "Values", "Value", true, {} },
    }
    for _, item in ipairs(items) do
       local kind = Generator.item_kind(item, env)
@@ -340,33 +345,43 @@ function SiteApi.summary(
       elseif item.kind == "type" then
          group = 1
       end
-      table.insert(groups[group][3], item)
+      table.insert(groups[group][4], item)
    end
 
    local output = {}
    for _, group in ipairs(groups) do
-      local heading, column, group_items = group[1], group[2], group[3]
+      local heading, column = group[1], group[2]
+      local show_kind, group_items = group[3], group[4]
       if #group_items > 0 then
          if #output > 0 then
             table.insert(output, "\n")
          end
          table.insert(output, "### " .. heading .. "\n\n")
-         table.insert(output, "| " .. column .. " | Kind | Description |\n")
-         table.insert(output, "| --- | --- | --- |\n")
-         for _, item in ipairs(group_items) do
-            local url = resolver(item.path) or "#" .. item.path
-            local kind = Generator.item_kind(item, env)
+         if show_kind then
             table.insert(
             output,
-            "| [`" ..
-            item.name ..
-            "`](" ..
-            url ..
-            ') | <span class="tealdoc-kind-badge tealdoc-kind-' ..
-            kind ..
-            '">' ..
-            kind ..
-            "</span> | " ..
+            "| " .. column .. " | Kind | Description |\n")
+
+            table.insert(output, "| --- | --- | --- |\n")
+         else
+            table.insert(output, "| " .. column .. " | Description |\n")
+            table.insert(output, "| --- | --- |\n")
+         end
+         for _, item in ipairs(group_items) do
+            local url = resolver(item.path) or "#" .. item.path
+            local cells = "| [`" .. item.name .. "`](" .. url .. ") | "
+            if show_kind then
+               local kind = Generator.item_kind(item, env)
+               cells = cells ..
+               '<span class="tealdoc-kind-badge tealdoc-kind-' ..
+               kind ..
+               '">' ..
+               kind ..
+               "</span> | "
+            end
+            table.insert(
+            output,
+            cells ..
             item_summary(item, env) ..
             " |\n")
 

--- a/build/tealdoc/generator/site/api.lua
+++ b/build/tealdoc/generator/site/api.lua
@@ -235,6 +235,16 @@ function SiteApi.markdown(
    return markdown:sub(2)
 end
 
+
+
+
+local FUNCTION_KINDS = {
+   ["function"] = true,
+   method = true,
+   metamethod = true,
+   macro = true,
+}
+
 local function item_text(item, env)
    if item.text and item.text ~= "" then
       return item.text
@@ -313,27 +323,55 @@ function SiteApi.summary(
       return ""
    end
 
-   local output = {
-      "| API | Kind | Description |\n",
-      "| --- | --- | --- |\n",
+
+
+
+
+   local groups = {
+      { "Types", "Type", {} },
+      { "Functions", "Function", {} },
+      { "Values", "Value", {} },
    }
    for _, item in ipairs(items) do
-      local url = resolver(item.path) or "#" .. item.path
       local kind = Generator.item_kind(item, env)
-      table.insert(
-      output,
-      "| [`" ..
-      item.name ..
-      "`](" ..
-      url ..
-      ') | <span class="tealdoc-kind-badge tealdoc-kind-' ..
-      kind ..
-      '">' ..
-      kind ..
-      "</span> | " ..
-      item_summary(item, env) ..
-      " |\n")
+      local group = 3
+      if FUNCTION_KINDS[kind] then
+         group = 2
+      elseif item.kind == "type" then
+         group = 1
+      end
+      table.insert(groups[group][3], item)
+   end
 
+   local output = {}
+   for _, group in ipairs(groups) do
+      local heading, column, group_items = group[1], group[2], group[3]
+      if #group_items > 0 then
+         if #output > 0 then
+            table.insert(output, "\n")
+         end
+         table.insert(output, "### " .. heading .. "\n\n")
+         table.insert(output, "| " .. column .. " | Kind | Description |\n")
+         table.insert(output, "| --- | --- | --- |\n")
+         for _, item in ipairs(group_items) do
+            local url = resolver(item.path) or "#" .. item.path
+            local kind = Generator.item_kind(item, env)
+            table.insert(
+            output,
+            "| [`" ..
+            item.name ..
+            "`](" ..
+            url ..
+            ') | <span class="tealdoc-kind-badge tealdoc-kind-' ..
+            kind ..
+            '">' ..
+            kind ..
+            "</span> | " ..
+            item_summary(item, env) ..
+            " |\n")
+
+         end
+      end
    end
    return table.concat(output)
 end

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -1060,8 +1060,15 @@ print(value)
         assert.is_falsy(api:find("Every public item", 1, true))
         assert.is_truthy(api:find("<th>Function</th>", 1, true), api)
         assert.is_truthy(markdown:find("### Functions", 1, true), markdown)
+        -- The functions table carries no kind column, so a row goes straight
+        -- from the name to the description.
         assert.is_truthy(markdown:find(
-            "| [`reset`](/modules/api/#api.reset) | <span class=\"tealdoc-kind-badge tealdoc-kind-method\">method</span> |",
+            "| [`reset`](/modules/api/#api.reset) | ",
+            1,
+            true
+        ), markdown)
+        assert.is_falsy(markdown:find(
+            "| [`reset`](/modules/api/#api.reset) | <span",
             1,
             true
         ), markdown)

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -1058,7 +1058,8 @@ print(value)
         assert.is_truthy(api:find("<h4", 1, true))
         assert.is_falsy(api:find("Public APIs in", 1, true))
         assert.is_falsy(api:find("Every public item", 1, true))
-        assert.is_truthy(api:find("<th>API</th>", 1, true), api)
+        assert.is_truthy(api:find("<th>Function</th>", 1, true), api)
+        assert.is_truthy(markdown:find("### Functions", 1, true), markdown)
         assert.is_truthy(markdown:find(
             "| [`reset`](/modules/api/#api.reset) | <span class=\"tealdoc-kind-badge tealdoc-kind-method\">method</span> |",
             1,

--- a/src/tealdoc/generator/site/api.tl
+++ b/src/tealdoc/generator/site/api.tl
@@ -327,10 +327,15 @@ function SiteApi.summary(
     -- reader arriving at a module wants either the shapes it defines or the
     -- calls it answers, and interleaving them by name means reading the kind
     -- column of every row to find out which of the two a name is.
-    local groups: {{string, string, {tealdoc.Item}}} = {
-        { "Types", "Type", {} },
-        { "Functions", "Function", {} },
-        { "Values", "Value", {} },
+    -- A kind column earns its place where the group holds more than one kind:
+    -- a type is a record or an interface or an enum, a value is a field or a
+    -- variable. Everything under Functions is called the same way whatever
+    -- `item_kind` names it, and the detail below carries the badge anyway, so
+    -- a column there would repeat the heading on every row.
+    local groups: {{string, string, boolean, {tealdoc.Item}}} = {
+        { "Types", "Type", true, {} },
+        { "Functions", "Function", false, {} },
+        { "Values", "Value", true, {} },
     }
     for _, item in ipairs(items) do
         local kind = Generator.item_kind(item, env)
@@ -340,33 +345,43 @@ function SiteApi.summary(
         elseif item is tealdoc.TypeItem then
             group = 1
         end
-        table.insert(groups[group][3], item)
+        table.insert(groups[group][4], item)
     end
 
     local output: {string} = {}
     for _, group in ipairs(groups) do
-        local heading, column, group_items = group[1], group[2], group[3]
+        local heading, column = group[1], group[2]
+        local show_kind, group_items = group[3], group[4]
         if #group_items > 0 then
             if #output > 0 then
                 table.insert(output, "\n")
             end
             table.insert(output, "### " .. heading .. "\n\n")
-            table.insert(output, "| " .. column .. " | Kind | Description |\n")
-            table.insert(output, "| --- | --- | --- |\n")
-            for _, item in ipairs(group_items) do
-                local url = resolver(item.path) or "#" .. item.path
-                local kind = Generator.item_kind(item, env)
+            if show_kind then
                 table.insert(
                     output,
-                    "| [`" ..
-                        item.name ..
-                        "`](" ..
-                        url ..
-                        ') | <span class="tealdoc-kind-badge tealdoc-kind-' ..
+                    "| " .. column .. " | Kind | Description |\n"
+                )
+                table.insert(output, "| --- | --- | --- |\n")
+            else
+                table.insert(output, "| " .. column .. " | Description |\n")
+                table.insert(output, "| --- | --- |\n")
+            end
+            for _, item in ipairs(group_items) do
+                local url = resolver(item.path) or "#" .. item.path
+                local cells = "| [`" .. item.name .. "`](" .. url .. ") | "
+                if show_kind then
+                    local kind = Generator.item_kind(item, env)
+                    cells = cells ..
+                        '<span class="tealdoc-kind-badge tealdoc-kind-' ..
                         kind ..
                         '">' ..
                         kind ..
-                        "</span> | " ..
+                        "</span> | "
+                end
+                table.insert(
+                    output,
+                    cells ..
                         item_summary(item, env) ..
                         " |\n"
                 )

--- a/src/tealdoc/generator/site/api.tl
+++ b/src/tealdoc/generator/site/api.tl
@@ -235,6 +235,16 @@ function SiteApi.markdown(
     return markdown:sub(2)
 end
 
+-- The kinds `Generator.item_kind` answers for something a caller calls. What
+-- is left over after these and the types is a value: a field, a variable, an
+-- enum member.
+local FUNCTION_KINDS: {string: boolean} = {
+    ["function"] = true,
+    method = true,
+    metamethod = true,
+    macro = true,
+}
+
 local function item_text(item: tealdoc.Item, env: tealdoc.Env): string
     if item.text and item.text ~= "" then
         return item.text
@@ -313,27 +323,55 @@ function SiteApi.summary(
         return ""
     end
 
-    local output: {string} = {
-        "| API | Kind | Description |\n",
-        "| --- | --- | --- |\n",
+    -- One table per group rather than one alphabetical list of everything. A
+    -- reader arriving at a module wants either the shapes it defines or the
+    -- calls it answers, and interleaving them by name means reading the kind
+    -- column of every row to find out which of the two a name is.
+    local groups: {{string, string, {tealdoc.Item}}} = {
+        { "Types", "Type", {} },
+        { "Functions", "Function", {} },
+        { "Values", "Value", {} },
     }
     for _, item in ipairs(items) do
-        local url = resolver(item.path) or "#" .. item.path
         local kind = Generator.item_kind(item, env)
-        table.insert(
-            output,
-            "| [`" ..
-                item.name ..
-                "`](" ..
-                url ..
-                ') | <span class="tealdoc-kind-badge tealdoc-kind-' ..
-                kind ..
-                '">' ..
-                kind ..
-                "</span> | " ..
-                item_summary(item, env) ..
-                " |\n"
-        )
+        local group = 3
+        if FUNCTION_KINDS[kind] then
+            group = 2
+        elseif item is tealdoc.TypeItem then
+            group = 1
+        end
+        table.insert(groups[group][3], item)
+    end
+
+    local output: {string} = {}
+    for _, group in ipairs(groups) do
+        local heading, column, group_items = group[1], group[2], group[3]
+        if #group_items > 0 then
+            if #output > 0 then
+                table.insert(output, "\n")
+            end
+            table.insert(output, "### " .. heading .. "\n\n")
+            table.insert(output, "| " .. column .. " | Kind | Description |\n")
+            table.insert(output, "| --- | --- | --- |\n")
+            for _, item in ipairs(group_items) do
+                local url = resolver(item.path) or "#" .. item.path
+                local kind = Generator.item_kind(item, env)
+                table.insert(
+                    output,
+                    "| [`" ..
+                        item.name ..
+                        "`](" ..
+                        url ..
+                        ') | <span class="tealdoc-kind-badge tealdoc-kind-' ..
+                        kind ..
+                        '">' ..
+                        kind ..
+                        "</span> | " ..
+                        item_summary(item, env) ..
+                        " |\n"
+                )
+            end
+        end
     end
     return table.concat(output)
 end


### PR DESCRIPTION
The reference was one alphabetical table of everything a module holds, so finding the shapes it defines meant reading the kind column of every row. It is now a table per group, with an empty group omitted.