### PR TITLE
Give a group's row the same rhythm as a plain one

### DIFF
--- a/build/tealdoc/generator/site/css/navigation.lua
+++ b/build/tealdoc/generator/site/css/navigation.lua
@@ -99,14 +99,22 @@ return [[
     background: transparent;
 }
 
+/* A group's own row is a row like any other, so it takes the item padding and
+ * the inherited line box rather than a set of its own: the two differed by
+ * seven pixels, and the rows of a sidebar holding both read as unevenly
+ * spaced. The right side is wider than the token asks for, because the marker
+ * sits there. `line-height` is claimed back from Pico, which sets 1rem on
+ * every `summary` and so shortened only the rows that are groups. */
 .tealdoc-sidebar-section summary {
     position: relative;
     margin: 0;
-    padding: 0.22rem 1.2rem 0 0.55rem;
+    padding: var(--tealdoc-sidebar-item-padding);
+    padding-right: 1.2rem;
     cursor: pointer;
     font-family: var(--tealdoc-sidebar-font-family);
     font-size: var(--tealdoc-sidebar-heading-font-size);
     font-weight: var(--tealdoc-sidebar-heading-font-weight);
+    line-height: inherit;
     list-style: none;
 }
 
@@ -131,9 +139,11 @@ return [[
     margin-bottom: 0;
 }
 
+/* The marker centers against the row rather than sitting a fixed distance
+ * from its top, so it stays put whatever the item padding is set to. */
 .tealdoc-sidebar-section summary::after {
     position: absolute;
-    top: 0.35rem;
+    top: 50%;
     right: 0.35rem;
     color: var(--tealdoc-text-faint);
     width: auto;
@@ -142,12 +152,13 @@ return [[
     background-image: none !important;
     content: "›";
     font-size: 1rem;
-    transform: rotate(90deg);
+    line-height: 1;
+    transform: translateY(-50%) rotate(90deg);
     transition: transform 120ms ease;
 }
 
 .tealdoc-sidebar-section details:not([open]) summary::after {
-    transform: rotate(0);
+    transform: translateY(-50%) rotate(0);
 }
 
 .tealdoc-sidebar-section ul {

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -1445,7 +1445,11 @@ print(value)
             true
         ))
         assert.is_truthy(css:find(
-            ".tealdoc-sidebar-section summary {\n    position: relative;\n    margin: 0;\n    padding: 0.22rem 1.2rem 0 0.55rem;",
+            ".tealdoc-sidebar-section summary {\n" ..
+                "    position: relative;\n" ..
+                "    margin: 0;\n" ..
+                "    padding: var(--tealdoc-sidebar-item-padding);\n" ..
+                "    padding-right: 1.2rem;",
             1,
             true
         ))

--- a/src/tealdoc/generator/site/css/navigation.tl
+++ b/src/tealdoc/generator/site/css/navigation.tl
@@ -99,14 +99,22 @@ return [[
     background: transparent;
 }
 
+/* A group's own row is a row like any other, so it takes the item padding and
+ * the inherited line box rather than a set of its own: the two differed by
+ * seven pixels, and the rows of a sidebar holding both read as unevenly
+ * spaced. The right side is wider than the token asks for, because the marker
+ * sits there. `line-height` is claimed back from Pico, which sets 1rem on
+ * every `summary` and so shortened only the rows that are groups. */
 .tealdoc-sidebar-section summary {
     position: relative;
     margin: 0;
-    padding: 0.22rem 1.2rem 0 0.55rem;
+    padding: var(--tealdoc-sidebar-item-padding);
+    padding-right: 1.2rem;
     cursor: pointer;
     font-family: var(--tealdoc-sidebar-font-family);
     font-size: var(--tealdoc-sidebar-heading-font-size);
     font-weight: var(--tealdoc-sidebar-heading-font-weight);
+    line-height: inherit;
     list-style: none;
 }
 
@@ -131,9 +139,11 @@ return [[
     margin-bottom: 0;
 }
 
+/* The marker centers against the row rather than sitting a fixed distance
+ * from its top, so it stays put whatever the item padding is set to. */
 .tealdoc-sidebar-section summary::after {
     position: absolute;
-    top: 0.35rem;
+    top: 50%;
     right: 0.35rem;
     color: var(--tealdoc-text-faint);
     width: auto;
@@ -142,12 +152,13 @@ return [[
     background-image: none !important;
     content: "›";
     font-size: 1rem;
-    transform: rotate(90deg);
+    line-height: 1;
+    transform: translateY(-50%) rotate(90deg);
     transition: transform 120ms ease;
 }
 
 .tealdoc-sidebar-section details:not([open]) summary::after {
-    transform: rotate(0);
+    transform: translateY(-50%) rotate(0);
 }
 
 .tealdoc-sidebar-section ul {


### PR DESCRIPTION
A group's row was 24.4px tall against a plain row's 31.7px, so a sidebar holding both read as unevenly spaced. Two causes: the summary carried its own padding (`0.22rem ... 0`, against the item token's `0.24rem` on both sides), and Pico sets `line-height: 1rem` on every `summary`, which shortened only the rows that are groups.

The summary now takes the item padding and the inherited line box, widened on the right for the marker, and the marker centers against the row rather than sitting a fixed distance from its top.