### PR TITLE
Label a code block with its language

### DIFF
--- a/build/tealdoc/generator/site/css/content.lua
+++ b/build/tealdoc/generator/site/css/content.lua
@@ -161,6 +161,36 @@ return [[
     opacity: 1;
 }
 
+/* The wrapper exists to hold the language label still. The `pre` inside it is
+ * the horizontal scroll container, and anything positioned against a scroll
+ * container travels with its content. */
+.tealdoc-content .tealdoc-code-block {
+    position: relative;
+}
+
+/* The label is a pseudo-element's content rather than an element of its own,
+ * so it is neither in the text a reader copies out of the block nor in what
+ * the search index reads. */
+.tealdoc-content .tealdoc-code-block[data-lang]::before {
+    position: absolute;
+    z-index: 1;
+    top: var(--tealdoc-code-lang-top);
+    right: var(--tealdoc-code-lang-right);
+    color: var(--tealdoc-code-lang-color);
+    content: attr(data-lang);
+    font-family: var(--tealdoc-font-mono);
+    font-size: var(--tealdoc-code-lang-font-size);
+    line-height: 1;
+    pointer-events: none;
+    user-select: none;
+}
+
+/* A labelled block keeps the label's own room above the first line, so the
+ * two never sit on top of one another. */
+.tealdoc-content .tealdoc-code-block[data-lang] > pre {
+    padding-top: var(--tealdoc-code-lang-clearance);
+}
+
 .tealdoc-content pre {
     overflow: auto;
     padding: var(--tealdoc-code-block-padding);

--- a/build/tealdoc/generator/site/css/tokens.lua
+++ b/build/tealdoc/generator/site/css/tokens.lua
@@ -50,6 +50,11 @@ return [[
     --tealdoc-code-block-font-size: 0.8rem;
     --tealdoc-code-block-radius: 8px;
     --tealdoc-code-block-padding: 0.8rem 0.9rem;
+    --tealdoc-code-lang-color: var(--tealdoc-text-faint);
+    --tealdoc-code-lang-font-size: 0.68rem;
+    --tealdoc-code-lang-top: 0.55rem;
+    --tealdoc-code-lang-right: 0.75rem;
+    --tealdoc-code-lang-clearance: 1.8rem;
     --tealdoc-inline-code-font-size: 0.91em;
     --tealdoc-inline-code-padding: 0.1em 0.35em;
     --tealdoc-inline-code-radius: 4px;

--- a/build/tealdoc/generator/site/markdown.lua
+++ b/build/tealdoc/generator/site/markdown.lua
@@ -285,30 +285,50 @@ function SiteMarkdown.render(
 
 
    html = html:gsub("\n+(</code></pre>)", "%1")
-   local function highlight_code(
-      language,
-      links)
 
-      html = html:gsub(
-      '<pre><code class="language%-' .. language .. '">(.-)</code></pre>',
-      function(code)
-         code = code:gsub("&lt;", "<"):
-         gsub("&gt;", ">"):
-         gsub("&quot;", '"'):
-         gsub("&#39;", "'"):
-         gsub("&amp;", "&")
-         return '<pre class="language-' ..
-         language ..
-         '"><code class="language-' ..
-         language ..
-         '">' ..
-         Highlighter.highlight(code, links) ..
-         "</code></pre>"
-      end)
 
-   end
-   highlight_code("teal", type_links)
-   highlight_code("lua")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+   local links_for = {
+      teal = type_links or {},
+      lua = {},
+   }
+   html = html:gsub(
+   '<pre><code class="language%-([^"]+)">(.-)</code></pre>',
+   function(info, code)
+      local language = info:match("^([%w_#+-]+)") or info
+      code = code:gsub("&lt;", "<"):
+      gsub("&gt;", ">"):
+      gsub("&quot;", '"'):
+      gsub("&#39;", "'"):
+      gsub("&amp;", "&")
+      local links = links_for[language]
+      local body = links and
+      Highlighter.highlight(code, links) or
+      escape_html(code)
+      return '<div class="tealdoc-code-block" data-lang="' ..
+      escape_html(language) ..
+      '"><pre class="language-' ..
+      escape_html(info) ..
+      '"><code class="language-' ..
+      escape_html(info) ..
+      '">' ..
+      body ..
+      "</code></pre></div>"
+   end)
+
    return html
 end
 

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -3,6 +3,7 @@ local DefaultEnv = require("tealdoc.default_env")
 local SiteGenerator = require("tealdoc.generator.site")
 local Highlighter = require("tealdoc.generator.site.highlighter")
 local PageTemplate = require("tealdoc.generator.site.page_template")
+local SiteMarkdown = require("tealdoc.generator.site.markdown")
 local tealdoc = require("tealdoc")
 
 local function read_file(path)
@@ -212,6 +213,34 @@ describe("Site generator", function()
         )
         assert.is_falsy(declaration:find("tealdoc-code-link", 1, true))
     end)
+
+    it("labels a fenced block and highlights it through its attributes",
+        function()
+            local html = SiteMarkdown.render(
+                "```teal{2}\nlocal a = 1\nlocal b = 2\n```\n",
+                {}
+            )
+            -- The attributes are cut before the language is looked up, so the
+            -- block highlights, and the label reads the language rather than
+            -- the whole info string.
+            assert.is_truthy(html:find(
+                '<div class="tealdoc-code-block" data-lang="teal">',
+                1,
+                true
+            ), html)
+            assert.is_truthy(html:find("tealdoc-token-keyword", 1, true), html)
+            -- What was written stays on the class, so a site can style it.
+            assert.is_truthy(html:find('class="language-teal{2}"', 1, true), html)
+
+            -- A language with no tokenizer is labelled and left alone.
+            local shell = SiteMarkdown.render("```bash\nls -l\n```\n", {})
+            assert.is_truthy(shell:find(
+                '<div class="tealdoc-code-block" data-lang="bash">',
+                1,
+                true
+            ), shell)
+            assert.is_falsy(shell:find("tealdoc-token-", 1, true))
+        end)
 
     it("assembles one public API page from several source modules", function()
         local env = DefaultEnv.init()
@@ -1625,6 +1654,14 @@ print(value)
         assert.is_falsy(redirect:find("<script", 1, true))
         assert.is_truthy(example_html:find(
             'keyword-local tealdoc-token-keyword">local</span>',
+            1,
+            true
+        ), example_html)
+        -- Every block is wrapped, and the wrapper carries the language on its
+        -- own so the corner label has something to draw and does not sit on
+        -- the element that scrolls.
+        assert.is_truthy(example_html:find(
+            '<div class="tealdoc-code-block" data-lang="teal"><pre',
             1,
             true
         ), example_html)

--- a/src/tealdoc/generator/site/css/content.tl
+++ b/src/tealdoc/generator/site/css/content.tl
@@ -161,6 +161,36 @@ return [[
     opacity: 1;
 }
 
+/* The wrapper exists to hold the language label still. The `pre` inside it is
+ * the horizontal scroll container, and anything positioned against a scroll
+ * container travels with its content. */
+.tealdoc-content .tealdoc-code-block {
+    position: relative;
+}
+
+/* The label is a pseudo-element's content rather than an element of its own,
+ * so it is neither in the text a reader copies out of the block nor in what
+ * the search index reads. */
+.tealdoc-content .tealdoc-code-block[data-lang]::before {
+    position: absolute;
+    z-index: 1;
+    top: var(--tealdoc-code-lang-top);
+    right: var(--tealdoc-code-lang-right);
+    color: var(--tealdoc-code-lang-color);
+    content: attr(data-lang);
+    font-family: var(--tealdoc-font-mono);
+    font-size: var(--tealdoc-code-lang-font-size);
+    line-height: 1;
+    pointer-events: none;
+    user-select: none;
+}
+
+/* A labelled block keeps the label's own room above the first line, so the
+ * two never sit on top of one another. */
+.tealdoc-content .tealdoc-code-block[data-lang] > pre {
+    padding-top: var(--tealdoc-code-lang-clearance);
+}
+
 .tealdoc-content pre {
     overflow: auto;
     padding: var(--tealdoc-code-block-padding);

--- a/src/tealdoc/generator/site/css/tokens.tl
+++ b/src/tealdoc/generator/site/css/tokens.tl
@@ -50,6 +50,11 @@ return [[
     --tealdoc-code-block-font-size: 0.8rem;
     --tealdoc-code-block-radius: 8px;
     --tealdoc-code-block-padding: 0.8rem 0.9rem;
+    --tealdoc-code-lang-color: var(--tealdoc-text-faint);
+    --tealdoc-code-lang-font-size: 0.68rem;
+    --tealdoc-code-lang-top: 0.55rem;
+    --tealdoc-code-lang-right: 0.75rem;
+    --tealdoc-code-lang-clearance: 1.8rem;
     --tealdoc-inline-code-font-size: 0.91em;
     --tealdoc-inline-code-padding: 0.1em 0.35em;
     --tealdoc-inline-code-radius: 4px;

--- a/src/tealdoc/generator/site/markdown.tl
+++ b/src/tealdoc/generator/site/markdown.tl
@@ -285,30 +285,50 @@ function SiteMarkdown.render(
     -- A fence carries a newline before its closing line, and a browser renders
     -- that as a blank last line inside the block. Nobody wrote it, so it goes.
     html = html:gsub("\n+(</code></pre>)", "%1")
-    local function highlight_code(
-        language: string,
-        links?: Highlighter.Links
+    -- One pass over every fenced block, whatever it is written in.
+    --
+    -- The language is captured rather than built into the pattern, so a fence
+    -- carrying attributes is found too. Lunamark writes the whole info string
+    -- into the class, and `teal{3}` never matched a pattern assembled from
+    -- `teal`: those blocks shipped unhighlighted and nothing reported it. The
+    -- attributes are cut before the language is looked up and left on the
+    -- class, so a site can still style them and nothing here has to know what
+    -- they mean.
+    --
+    -- The wrapper is what carries the language for the corner label. It
+    -- cannot be the `pre`, which is the horizontal scroll container: a label
+    -- positioned against that scrolls out of the corner it is meant to sit in
+    -- as soon as the block is wide enough to scroll. The label is drawn from
+    -- `data-lang` by CSS rather than written as an element, so it stays out
+    -- of the search index and out of whatever a reader copies.
+    local links_for: {string: Highlighter.Links} = {
+        teal = type_links or {},
+        lua = {},
+    }
+    html = html:gsub(
+        '<pre><code class="language%-([^"]+)">(.-)</code></pre>',
+        function(info: string, code: string): string
+            local language = info:match("^([%w_#+-]+)") or info
+            code = code:gsub("&lt;", "<")
+                :gsub("&gt;", ">")
+                :gsub("&quot;", '"')
+                :gsub("&#39;", "'")
+                :gsub("&amp;", "&")
+            local links = links_for[language]
+            local body = links
+                and Highlighter.highlight(code, links)
+                or escape_html(code)
+            return '<div class="tealdoc-code-block" data-lang="' ..
+                escape_html(language) ..
+                '"><pre class="language-' ..
+                escape_html(info) ..
+                '"><code class="language-' ..
+                escape_html(info) ..
+                '">' ..
+                body ..
+                "</code></pre></div>"
+        end
     )
-        html = html:gsub(
-            '<pre><code class="language%-' .. language .. '">(.-)</code></pre>',
-            function(code: string): string
-                code = code:gsub("&lt;", "<")
-                    :gsub("&gt;", ">")
-                    :gsub("&quot;", '"')
-                    :gsub("&#39;", "'")
-                    :gsub("&amp;", "&")
-                return '<pre class="language-' ..
-                    language ..
-                    '"><code class="language-' ..
-                    language ..
-                    '">' ..
-                    Highlighter.highlight(code, links) ..
-                    "</code></pre>"
-            end
-        )
-    end
-    highlight_code("teal", type_links)
-    highlight_code("lua")
     return html
 end
 


### PR DESCRIPTION
Every fenced block is wrapped and the wrapper carries `data-lang`, which CSS draws in the top-right corner. The label is a pseudo-element's content rather than an element, so it is not in the text a reader copies and not in the search index. It sits on the wrapper and not the `pre`, which is the horizontal scroll container: a label positioned against that scrolls out of its corner as soon as the block is wide enough to scroll.

The same pass fixes the matching bug it needed fixed anyway. The language is captured rather than built into the pattern, so a fence carrying attributes is found: lunamark writes the whole info string into the class, and `teal{3}` never matched a pattern assembled from `teal`, so those blocks shipped unhighlighted with nothing reporting it. In one tecs page five such blocks went from 0 highlight spans to 17-45. The attributes are cut before the language is looked up and left on the class.