### PR TITLE
Highlight non-Teal blocks through lexers a site points at

### DIFF
--- a/build/tealdoc/generator/site.lua
+++ b/build/tealdoc/generator/site.lua
@@ -9,6 +9,7 @@ local PageTemplate = require("tealdoc.generator.site.page_template")
 local SiteApi = require("tealdoc.generator.site.api")
 local SiteConfig = require("tealdoc.generator.site.config")
 local SiteExamples = require("tealdoc.generator.site.examples")
+local Scintillua = require("tealdoc.generator.site.scintillua")
 local SiteMarkdown = require("tealdoc.generator.site.markdown")
 local SiteTypes = require("tealdoc.generator.site.types")
 local SiteValidator = require("tealdoc.generator.site.validator")
@@ -1884,6 +1885,10 @@ function SiteGenerator.build(
    config_directory)
 
    local settings = SiteConfig.configure(raw_settings, config_directory)
+
+
+
+   Scintillua.configure(settings.lexers)
    local pages
    local attached_examples
    pages, attached_examples = SiteExamples.prepare(settings, env)

--- a/build/tealdoc/generator/site/config.lua
+++ b/build/tealdoc/generator/site/config.lua
@@ -94,6 +94,7 @@ local site_keys = {
    robots = true,
    not_found = true,
    custom_css = true,
+   lexers = true,
    templates = true,
    copyright = true,
    license = true,
@@ -251,6 +252,7 @@ function SiteConfig.configure(
          "social_image",
          "twitter_site",
          "custom_css",
+         "lexers",
          "templates",
          "copyright",
          "license",
@@ -325,6 +327,7 @@ function SiteConfig.configure(
       "tealdoc.site.custom_css") or
 
       nil,
+      lexers = values["lexers"],
       templates = values["templates"] and
       resolve_file_path(
       directory,

--- a/build/tealdoc/generator/site/highlighter.lua
+++ b/build/tealdoc/generator/site/highlighter.lua
@@ -1,7 +1,14 @@
 local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local tl = require("tl")
 local Text = require("tealdoc.generator.text")
 
-local Highlighter = {}
+local Highlighter = { Segment = {} }
+
+
+
+
+
+
+
 
 
 
@@ -187,6 +194,10 @@ function Highlighter.highlight(code, links)
       return a.first < b.first
    end)
 
+   return Highlighter.render(code, segments)
+end
+
+function Highlighter.render(code, segments)
    local output = {}
    local cursor = 1
    for _, segment in ipairs(segments) do

--- a/build/tealdoc/generator/site/markdown.lua
+++ b/build/tealdoc/generator/site/markdown.lua
@@ -1,5 +1,6 @@
 local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local pcall = _tl_compat and _tl_compat.pcall or pcall; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local HTMLBuilder = require("tealdoc.generator.html.builder")
 local Highlighter = require("tealdoc.generator.site.highlighter")
+local Scintillua = require("tealdoc.generator.site.scintillua")
 local Text = require("tealdoc.generator.text")
 
 local SiteMarkdown = {}
@@ -314,10 +315,20 @@ function SiteMarkdown.render(
       gsub("&quot;", '"'):
       gsub("&#39;", "'"):
       gsub("&amp;", "&")
+
+
+
+
       local links = links_for[language]
-      local body = links and
-      Highlighter.highlight(code, links) or
-      escape_html(code)
+      local body
+      if links then
+         body = Highlighter.highlight(code, links)
+      else
+         local segments = Scintillua.segments(language, code)
+         body = segments and
+         Highlighter.render(code, segments) or
+         escape_html(code)
+      end
       return '<div class="tealdoc-code-block" data-lang="' ..
       escape_html(language) ..
       '"><pre class="language-' ..

--- a/build/tealdoc/generator/site/scintillua.lua
+++ b/build/tealdoc/generator/site/scintillua.lua
@@ -1,0 +1,189 @@
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local loadfile = _tl_compat and _tl_compat.loadfile or loadfile; local pcall = _tl_compat and _tl_compat.pcall or pcall; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+local Highlighter = require("tealdoc.generator.site.highlighter")
+
+local Scintillua = {}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+local LEXERS = {
+   bash = true,
+   json = true,
+   xml = true,
+}
+
+
+
+
+
+
+
+
+local STYLES = {
+   keyword = "keyword",
+   comment = "comment",
+   string = "string",
+   number = "number",
+   operator = "operator",
+   identifier = "variable",
+   ["function"] = "function",
+   type = "type",
+   class = "type",
+   constant = "boolean",
+   variable = "variable",
+   preprocessor = "meta",
+   annotation = "meta",
+   label = "meta",
+   embedded = "meta",
+   regex = "string",
+
+   tag = "keyword",
+   attribute = "property",
+   entity = "boolean",
+   property = "property",
+}
+
+
+
+
+
+local directory = nil
+
+
+
+
+
+
+
+
+
+
+
+
+
+local library_module = nil
+local loaded = {}
+local searched = false
+
+function Scintillua.configure(lexers)
+   if lexers == directory then
+      return
+   end
+   directory = lexers
+   library_module = nil
+   loaded = {}
+   searched = false
+end
+
+local function library()
+   if searched then
+      return library_module
+   end
+   searched = true
+   if not directory then
+      return nil
+   end
+   local chunk = loadfile(directory .. "/lexer.lua")
+   if not chunk then
+      return nil
+   end
+   local ok, module = pcall(chunk)
+   if not ok or not module then
+      return nil
+   end
+   library_module = module
+
+
+   library_module.property = setmetatable(
+   { ["scintillua.lexers"] = directory },
+   { __index = function() return "" end })
+
+   return library_module
+end
+
+function Scintillua.supports(language)
+   return LEXERS[language] == true
+end
+
+function Scintillua.segments(
+   language,
+   code)
+
+   if not LEXERS[language] then
+      return nil
+   end
+   local module = library()
+   if not module then
+      return nil
+   end
+   local lexer = loaded[language]
+   if not lexer then
+      local ok, result = pcall(module.load, language)
+      if not ok or not result then
+         return nil
+      end
+      lexer = result
+      loaded[language] = lexer
+   end
+   local ok, tags = pcall(lexer.lex, lexer, code)
+   if not ok or not tags then
+      return nil
+   end
+
+
+
+
+
+   local list = tags
+   local segments = {}
+   local cursor = 1
+   for index = 1, #list - 1, 2 do
+      local tag = list[index]
+      local stop = list[index + 1]
+      local first, last = cursor, stop - 1
+      cursor = stop
+      local style = STYLES[(tag:match("^[^.]+") or tag)]
+      if style and last >= first then
+         table.insert(segments, {
+            first = first,
+            last = last,
+            style = style,
+         })
+      end
+   end
+   return segments
+end
+
+return Scintillua

--- a/build/tealdoc/generator/site/types.lua
+++ b/build/tealdoc/generator/site/types.lua
@@ -120,4 +120,5 @@ local SiteTypes = { Link = {}, Feature = {}, HeadEntry = {}, Page = {}, SidebarI
 
 
 
+
 return SiteTypes

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -266,6 +266,7 @@ settings document their complete nested table shape.
 | [`robots`](site_configuration.md#robots) | `true` | Generate `robots.txt`. |
 | [`not_found`](site_configuration.md#not_found) | omitted | Custom 404 page. |
 | [`custom_css`](site_configuration.md#custom_css) | omitted | Project stylesheet. |
+| [`lexers`](site_configuration.md#lexers) | omitted | Scintillua lexers for non-Teal blocks. |
 | [`templates`](site_configuration.md#templates) | omitted | Template override directory. |
 | [`copyright`](site_configuration.md#copyright) | omitted | Escaped footer copyright. |
 | [`license`](site_configuration.md#license) | omitted | Escaped footer license. |

--- a/docs/site_configuration.md
+++ b/docs/site_configuration.md
@@ -224,6 +224,25 @@ selectors can customize the theme without replacing templates.
 custom_css = "docs/site.css"
 ```
 
+## lexers
+
+Optional directory of [Scintillua](https://github.com/orbitalquark/scintillua)
+lexers, used to highlight fenced blocks in languages other than Teal.
+
+Teal and Lua are always highlighted through the Teal compiler's own lexer,
+which is what turns a type name in a code block into a link to the page that
+documents it. Every other language is read by whichever Scintillua lexer
+matches the fence's language, and a language with no lexer here is emitted
+exactly as it was written.
+
+Tealdoc neither vendors nor depends on Scintillua: it is not published on
+LuaRocks, so a site that wants these languages installs it and says where the
+lexers landed. Omit this and nothing changes.
+
+```lua
+lexers = "vendor/scintillua/lexers"
+```
+
 ## templates
 
 Optional config-relative directory containing narrow

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -242,6 +242,26 @@ describe("Site generator", function()
             assert.is_falsy(shell:find("tealdoc-token-", 1, true))
         end)
 
+    it("leaves a block alone when no lexer directory is configured", function()
+        -- The whole point of the setting being optional: a site that says
+        -- nothing about lexers gets exactly what it got before there were
+        -- any, rather than a hard dependency on a library that is not on
+        -- LuaRocks.
+        local Scintillua = require("tealdoc.generator.site.scintillua")
+        Scintillua.configure(nil)
+        local html = SiteMarkdown.render("```bash\nls -l # note\n```\n", {})
+        assert.is_truthy(html:find(
+            '<div class="tealdoc-code-block" data-lang="bash">',
+            1,
+            true
+        ), html)
+        assert.is_falsy(html:find("tealdoc-token-", 1, true), html)
+        Scintillua.configure("/tealdoc-spec/no/such/directory")
+        local missing = SiteMarkdown.render("```bash\nls -l\n```\n", {})
+        assert.is_falsy(missing:find("tealdoc-token-", 1, true), missing)
+        Scintillua.configure(nil)
+    end)
+
     it("assembles one public API page from several source modules", function()
         local env = DefaultEnv.init()
         env.no_warnings_on_missing = true

--- a/src/tealdoc/generator/site.tl
+++ b/src/tealdoc/generator/site.tl
@@ -9,6 +9,7 @@ local PageTemplate = require("tealdoc.generator.site.page_template")
 local SiteApi = require("tealdoc.generator.site.api")
 local SiteConfig = require("tealdoc.generator.site.config")
 local SiteExamples = require("tealdoc.generator.site.examples")
+local Scintillua = require("tealdoc.generator.site.scintillua")
 local SiteMarkdown = require("tealdoc.generator.site.markdown")
 local SiteTypes = require("tealdoc.generator.site.types")
 local SiteValidator = require("tealdoc.generator.site.validator")
@@ -1884,6 +1885,10 @@ function SiteGenerator.build(
     config_directory?: string
 )
     local settings = SiteConfig.configure(raw_settings, config_directory)
+    -- Where a site keeps its Scintillua lexers, if it keeps any. Set once for
+    -- the build rather than threaded through every render, because it is a
+    -- property of the installation and not of a page.
+    Scintillua.configure(settings.lexers)
     local pages: {SiteGenerator.Page}
     local attached_examples: {string: {PreparedExample}}
     pages, attached_examples = SiteExamples.prepare(settings, env)

--- a/src/tealdoc/generator/site/config.tl
+++ b/src/tealdoc/generator/site/config.tl
@@ -94,6 +94,7 @@ local site_keys: {string: boolean} = {
     robots = true,
     not_found = true,
     custom_css = true,
+    lexers = true,
     templates = true,
     copyright = true,
     license = true,
@@ -251,6 +252,7 @@ function SiteConfig.configure(
         "social_image",
         "twitter_site",
         "custom_css",
+        "lexers",
         "templates",
         "copyright",
         "license",
@@ -325,6 +327,7 @@ function SiteConfig.configure(
                 "tealdoc.site.custom_css"
             )
             or nil,
+        lexers = values["lexers"] as string,
         templates = values["templates"]
             and resolve_file_path(
                 directory,

--- a/src/tealdoc/generator/site/highlighter.tl
+++ b/src/tealdoc/generator/site/highlighter.tl
@@ -4,15 +4,22 @@ local Text = require("tealdoc.generator.text")
 local record Highlighter
     type Links = {string: string}
 
+    record Segment
+        first: integer
+        last: integer
+        style: string
+        url: string
+    end
+
     highlight: function(string, Links): string
+    --- Emits the spans a list of segments describes over the code they were
+    --- read from. Segments come from a tokenizer; this is the half that does
+    --- not care which one, so a lexer that is not Teal's reaches the same
+    --- markup and the same theme.
+    render: function(string, {Segment}): string
 end
 
-local record Segment
-    first: integer
-    last: integer
-    style: string
-    url: string
-end
+local type Segment = Highlighter.Segment
 
 local type_names: {string: boolean} = {
     ["any"] = true,
@@ -187,6 +194,10 @@ function Highlighter.highlight(code: string, links?: Highlighter.Links): string
         return a.first < b.first
     end)
 
+    return Highlighter.render(code, segments)
+end
+
+function Highlighter.render(code: string, segments: {Segment}): string
     local output: {string} = {}
     local cursor = 1
     for _, segment in ipairs(segments) do

--- a/src/tealdoc/generator/site/markdown.tl
+++ b/src/tealdoc/generator/site/markdown.tl
@@ -1,5 +1,6 @@
 local HTMLBuilder = require("tealdoc.generator.html.builder")
 local Highlighter = require("tealdoc.generator.site.highlighter")
+local Scintillua = require("tealdoc.generator.site.scintillua")
 local Text = require("tealdoc.generator.text")
 
 local record SiteMarkdown
@@ -314,10 +315,20 @@ function SiteMarkdown.render(
                 :gsub("&quot;", '"')
                 :gsub("&#39;", "'")
                 :gsub("&amp;", "&")
+            -- Teal and Lua go through the compiler's own lexer, which is
+            -- what carries the type links. Anything else Scintillua has a
+            -- grammar for reaches the same emitter through its segments, and
+            -- anything neither knows is left as it was written.
             local links = links_for[language]
-            local body = links
-                and Highlighter.highlight(code, links)
-                or escape_html(code)
+            local body: string
+            if links then
+                body = Highlighter.highlight(code, links)
+            else
+                local segments = Scintillua.segments(language, code)
+                body = segments
+                    and Highlighter.render(code, segments)
+                    or escape_html(code)
+            end
             return '<div class="tealdoc-code-block" data-lang="' ..
                 escape_html(language) ..
                 '"><pre class="language-' ..

--- a/src/tealdoc/generator/site/scintillua.tl
+++ b/src/tealdoc/generator/site/scintillua.tl
@@ -1,0 +1,189 @@
+--- Syntax highlighting for languages that are not Teal, through Scintillua's
+--- LPeg lexers.
+---
+--- Teal keeps its own tokenizer: `tl.lex` is the compiler's, and it is what
+--- lets a type name in a code block become a link to the page that documents
+--- it. No general grammar can do that. Everything else is a language whose
+--- grammar this project has no business writing, so it does not: the lexers
+--- are Scintillua's, vendored unmodified, and what is written here is the
+--- adapter between them and the emitter every block already goes through.
+---
+--- Nothing is vendored and nothing is depended on. Scintillua is not on
+--- LuaRocks, and copying a hundred kilobytes of somebody else's grammars into
+--- a documentation generator is not what a documentation generator is for. A
+--- site that wants languages beyond Teal installs Scintillua itself and says
+--- where it put the lexers, through `tealdoc.site.lexers`. A site that says
+--- nothing loses nothing: a block in a language nothing here reads is emitted
+--- exactly as it was written, which is what happened before any of this.
+---
+--- Scintillua answers a flat list alternating tag name and start offset,
+--- `{"keyword", 2, "whitespace.lua", 3}`, where a run reaches to the next
+--- offset. That converts to the segments the emitter already consumes, so a
+--- highlighted shell block reaches the same spans, the same classes and the
+--- same theme as a highlighted Teal one.
+local Highlighter = require("tealdoc.generator.site.highlighter")
+
+local record Scintillua
+    --- Answers the segments a language's lexer reads out of `code`, or nil
+    --- when no lexer is vendored for that language.
+    segments: function(string, string): {Highlighter.Segment}
+    --- Points the adapter at a directory of Scintillua lexers, or at nothing.
+    --- Called once for a build, before any page is rendered.
+    configure: function(string)
+end
+
+--- The languages to try a lexer for. Teal and Lua are absent on purpose: they
+--- go through the compiler's own lexer, which is better at them than any
+--- general grammar and is what carries the type links.
+---
+--- A name here is asked of Scintillua and dropped if it has no such lexer, so
+--- this list costs nothing when the directory is unset or incomplete.
+local LEXERS: {string: boolean} = {
+    bash = true,
+    json = true,
+    xml = true,
+}
+
+--- Scintillua's tag names against the styles the emitter already knows.
+---
+--- The tags are matched on their first component, because Scintillua names a
+--- subtype with a dot, `function.builtin`, and suffixes whitespace with the
+--- language, `whitespace.bash`. A tag with no entry here draws no span and
+--- reads as ordinary code, which is the right answer for `default` and for
+--- anything a lexer names that this theme has no colour for.
+local STYLES: {string: string} = {
+    keyword = "keyword",
+    comment = "comment",
+    string = "string",
+    number = "number",
+    operator = "operator",
+    identifier = "variable",
+    ["function"] = "function",
+    type = "type",
+    class = "type",
+    constant = "boolean",
+    variable = "variable",
+    preprocessor = "meta",
+    annotation = "meta",
+    label = "meta",
+    embedded = "meta",
+    regex = "string",
+    -- Markup, which is what the XML lexer answers in.
+    tag = "keyword",
+    attribute = "property",
+    entity = "boolean",
+    property = "property",
+}
+
+--- Where the lexers are, as the site said. Scintillua reads its own directory
+--- out of `scintillua.lexers` and loads a lexer with `loadfile` against a
+--- sandboxed environment, so nothing goes onto `package.path` and a lexer
+--- named `json` cannot be mistaken for anybody's JSON module.
+local directory: string = nil
+
+--- The shape of Scintillua this reaches for, which is two calls and one
+--- property. Naming it keeps the casting to the one place the library crosses
+--- into typed code.
+local record Lexer
+    lex: function(Lexer, string): {any}
+end
+
+local record Library
+    property: {string: string}
+    load: function(string): Lexer
+end
+
+local library_module: Library = nil
+local loaded: {string: Lexer} = {}
+local searched = false
+
+function Scintillua.configure(lexers: string)
+    if lexers == directory then
+        return
+    end
+    directory = lexers
+    library_module = nil
+    loaded = {}
+    searched = false
+end
+
+local function library(): Library
+    if searched then
+        return library_module
+    end
+    searched = true
+    if not directory then
+        return nil
+    end
+    local chunk = loadfile(directory .. "/lexer.lua")
+    if not chunk then
+        return nil
+    end
+    local ok, module = pcall(chunk)
+    if not ok or not module then
+        return nil
+    end
+    library_module = module as Library
+    -- Set explicitly rather than left to the library's own default, which is
+    -- every directory on `package.path`. A lexer is found here or not at all.
+    library_module.property = setmetatable(
+        { ["scintillua.lexers"] = directory } as {string: string},
+        { __index = function(): string return "" end }
+    )
+    return library_module
+end
+
+function Scintillua.supports(language: string): boolean
+    return LEXERS[language] == true
+end
+
+function Scintillua.segments(
+    language: string,
+    code: string
+): {Highlighter.Segment}
+    if not LEXERS[language] then
+        return nil
+    end
+    local module = library()
+    if not module then
+        return nil
+    end
+    local lexer = loaded[language]
+    if not lexer then
+        local ok, result = pcall(module.load, language)
+        if not ok or not result then
+            return nil
+        end
+        lexer = result as Lexer
+        loaded[language] = lexer
+    end
+    local ok, tags = pcall(lexer.lex, lexer, code)
+    if not ok or not tags then
+        return nil
+    end
+
+    -- The offset beside a tag is where the run *ends*, one past its last
+    -- byte, so a run reaches from wherever the previous one stopped. Reading
+    -- them as starts puts every span one token out of place, which is a thing
+    -- that looks almost right on a short line and falls apart on a real one.
+    local list = tags as {any}
+    local segments: {Highlighter.Segment} = {}
+    local cursor = 1
+    for index = 1, #list - 1, 2 do
+        local tag = list[index] as string
+        local stop = list[index + 1] as integer
+        local first, last = cursor, stop - 1
+        cursor = stop
+        local style = STYLES[(tag:match("^[^.]+") or tag)]
+        if style and last >= first then
+            table.insert(segments, {
+                first = first,
+                last = last,
+                style = style,
+            })
+        end
+    end
+    return segments
+end
+
+return Scintillua

--- a/src/tealdoc/generator/site/types.tl
+++ b/src/tealdoc/generator/site/types.tl
@@ -79,6 +79,7 @@ local record SiteTypes
         robots: boolean
         not_found: Page
         custom_css: string
+        lexers: string
         templates: string
         copyright: string
         license: string

--- a/tealdoc-dev-1.rockspec
+++ b/tealdoc-dev-1.rockspec
@@ -40,6 +40,7 @@ build = {
       ["tealdoc.generator.site.config"] = "build/tealdoc/generator/site/config.lua",
       ["tealdoc.generator.site.examples"] = "build/tealdoc/generator/site/examples.lua",
       ["tealdoc.generator.site.markdown"] = "build/tealdoc/generator/site/markdown.lua",
+      ["tealdoc.generator.site.scintillua"] = "build/tealdoc/generator/site/scintillua.lua",
       ["tealdoc.generator.site.types"] = "build/tealdoc/generator/site/types.lua",
       ["tealdoc.generator.site.view"] = "build/tealdoc/generator/site/view.lua",
       ["tealdoc.generator.site.validator"] = "build/tealdoc/generator/site/validator.lua",


### PR DESCRIPTION
Teal and Lua keep the compiler's own lexer, which is what turns a type name in a code block into a link. Every other language is read by a [Scintillua](https://github.com/orbitalquark/scintillua) lexer.

Tealdoc neither vendors nor depends on Scintillua. It is not on LuaRocks, and copying a hundred kilobytes of somebody else's grammars into a documentation generator earns nothing, so a site that wants these languages installs it and says where the lexers landed.

New setting, documented in `docs/site_configuration.md#lexers` and listed in `docs/cli_reference.md`:

```lua
tealdoc = {
    site = {
        lexers = "vendor/scintillua/lexers",
    },
}
```

Omit it and a block in an unknown language is emitted exactly as it was written, which is what happened before. A spec covers both the unset and the missing-directory cases, so it needs no Scintillua to run.