### PR TITLE
Ship the Teal source of the Scintillua adapter

### DIFF
--- a/tealdoc-dev-1.rockspec
+++ b/tealdoc-dev-1.rockspec
@@ -89,6 +89,7 @@ build = {
          ["tealdoc.generator.site.config"] = "src/tealdoc/generator/site/config.tl",
          ["tealdoc.generator.site.examples"] = "src/tealdoc/generator/site/examples.tl",
          ["tealdoc.generator.site.markdown"] = "src/tealdoc/generator/site/markdown.tl",
+         ["tealdoc.generator.site.scintillua"] = "src/tealdoc/generator/site/scintillua.tl",
          ["tealdoc.generator.site.types"] = "src/tealdoc/generator/site/types.tl",
          ["tealdoc.generator.site.view"] = "src/tealdoc/generator/site/view.tl",
          ["tealdoc.generator.site.validator"] = "src/tealdoc/generator/site/validator.tl",


### PR DESCRIPTION
The module reached `build.modules` but not `build.install.lua`, so the rock carried its compiled Lua and not the Teal it was compiled from. Every sibling ships both, and a dependent type-checking against tealdoc resolved this one to the Lua and lost its types.