### PR TITLE
Render module documentation in API sections

### DIFF
--- a/build/tealdoc.lua
+++ b/build/tealdoc.lua
@@ -330,6 +330,9 @@ local tealdoc = { Location = {}, Env = {}, Typearg = {}, TypeReference = {}, Fun
 
 
 
+
+
+
 tealdoc.version = "0.3+dev"
 
 function tealdoc.Env.init()

--- a/build/tealdoc/comment_parser.lua
+++ b/build/tealdoc/comment_parser.lua
@@ -7,8 +7,8 @@ local CommentParser = {}
 
 function CommentParser.parse_text(text, item, env)
    local lines = {}
-   for line in text:gmatch("[^\n]*") do
-      table.insert(lines, line)
+   for line in (text .. "\n"):gmatch("(.-)\n") do
+      table.insert(lines, (line:gsub("\r$", "")))
    end
    CommentParser.parse_lines(lines, item, env)
 end

--- a/build/tealdoc/generator/site.lua
+++ b/build/tealdoc/generator/site.lua
@@ -1589,7 +1589,7 @@ local function submodule_summary(
    end)
 
    local output = {
-      "### Submodules\n\n",
+      "**Submodules**\n\n",
       "| Submodule | Description |\n",
       "| --- | --- |\n",
    }
@@ -1618,26 +1618,29 @@ local function render_page(
    used_examples)
 
    local markdown = SiteApi.source_markdown(page)
-   local api = SiteApi.markdown(
+   local api, module_introduction = SiteApi.markdown(
    view,
    resolver,
    attached_examples,
    used_examples)
 
-   if api ~= "" then
+   if view then
       local summary = submodule_summary(page, context, context.settings.base) ..
       SiteApi.summary(view, resolver)
-      local introduction = ""
+      if summary ~= "" then
+         summary = "## Module contents\n\n" .. summary
+      end
       local public_name = view.public
       if not markdown:match("%S") then
-         introduction = "\n\nPublic APIs in `" .. public_name .. "`."
+         markdown = "# " .. public_name
       end
       markdown = markdown ..
-      "\n\n## " ..
-      public_name ..
-      " Reference" ..
-      introduction ..
       "\n\n" ..
+      (
+      module_introduction ~= "" and
+      module_introduction .. "\n\n" or
+      "") ..
+
       summary ..
       "\n" ..
       api

--- a/build/tealdoc/generator/site/api.lua
+++ b/build/tealdoc/generator/site/api.lua
@@ -145,6 +145,79 @@ function SiteApi.type_links(
    return links
 end
 
+
+
+
+local FUNCTION_KINDS = {
+   ["function"] = true,
+   method = true,
+   metamethod = true,
+   macro = true,
+}
+
+local function rebase_headings(text, target)
+   local lines = {}
+   for line in (text .. "\n"):gmatch("(.-)\n") do
+      table.insert(lines, (line:gsub("\r$", "")))
+   end
+
+   local shallowest
+   local fence_character
+   local fence_length = 0
+   for _, line in ipairs(lines) do
+      local fence = line:match("^%s*(```+)") or
+      line:match("^%s*(~~~+)")
+      if fence then
+         local character = fence:sub(1, 1)
+         if not fence_character then
+            fence_character = character
+            fence_length = #fence
+         elseif character == fence_character and #fence >= fence_length then
+            fence_character = nil
+            fence_length = 0
+         end
+      elseif not fence_character then
+         local hashes = line:match("^%s*(#+)%s+")
+         if hashes and #hashes <= 6 and
+            (not shallowest or #hashes < shallowest) then
+
+            shallowest = #hashes
+         end
+      end
+   end
+   if not shallowest then
+      return text
+   end
+
+   local shift = target - shallowest
+   fence_character = nil
+   fence_length = 0
+   for index, line in ipairs(lines) do
+      local fence = line:match("^%s*(```+)") or
+      line:match("^%s*(~~~+)")
+      if fence then
+         local character = fence:sub(1, 1)
+         if not fence_character then
+            fence_character = character
+            fence_length = #fence
+         elseif character == fence_character and #fence >= fence_length then
+            fence_character = nil
+            fence_length = 0
+         end
+      elseif not fence_character then
+         local indentation, hashes, rest =
+         line:match("^(%s*)(#+)(%s+.*)$")
+         if hashes and #hashes <= 6 then
+            local level = math.min(6, #hashes + shift)
+            lines[index] = indentation ..
+            string.rep("#", level) ..
+            rest
+         end
+      end
+   end
+   return table.concat(lines, "\n")
+end
+
 local function add_kind_badges(markdown, env)
    for path, item in pairs(env.registry) do
       if item.kind ~= "module" and Generator.filter(item, env) then
@@ -173,6 +246,88 @@ local function add_kind_badges(markdown, env)
    return markdown
 end
 
+local function group_details(
+   markdown,
+   view)
+
+   local env = view.env
+   local module = env.registry[view.public]
+   if not module or not module.children then
+      return ""
+   end
+
+   local positioned = {}
+   for _, path in ipairs(module.children) do
+      local item = env.registry[path]
+      if item and Generator.filter(item, env) then
+         local anchor = '<a id="' .. path .. '"></a>'
+         local start = markdown:find(anchor, 1, true)
+         if start then
+            table.insert(positioned, { item, start })
+         end
+      end
+   end
+   table.sort(
+   positioned,
+   function(
+      left,
+      right)
+
+      return left[2] < right[2]
+   end)
+
+
+   local details = {}
+   for index, entry in ipairs(positioned) do
+      local ending = index < #positioned and
+      positioned[index + 1][2] - 1 or
+      #markdown
+      details[entry[1].path] = markdown:sub(entry[2], ending):
+      gsub("^%s+", ""):
+      gsub("%s+$", "")
+   end
+
+   local items = {}
+   for _, entry in ipairs(positioned) do
+      table.insert(items, entry[1])
+   end
+   table.sort(items, function(a, b)
+      local left = a.name:lower()
+      local right = b.name:lower()
+      if left == right then
+         return a.path < b.path
+      end
+      return left < right
+   end)
+
+   local groups = {
+      { "Types", {} },
+      { "Functions", {} },
+      { "Values", {} },
+   }
+   for _, item in ipairs(items) do
+      local kind = Generator.item_kind(item, env)
+      local group = 3
+      if FUNCTION_KINDS[kind] then
+         group = 2
+      elseif item.kind == "type" then
+         group = 1
+      end
+      table.insert(groups[group][2], item)
+   end
+
+   local output = {}
+   for _, group in ipairs(groups) do
+      if #group[2] > 0 then
+         table.insert(output, "## " .. group[1])
+         for _, item in ipairs(group[2]) do
+            table.insert(output, details[item.path])
+         end
+      end
+   end
+   return table.concat(output, "\n\n")
+end
+
 function SiteApi.markdown(
    view,
    resolver,
@@ -180,15 +335,25 @@ function SiteApi.markdown(
    used_examples)
 
    if not view then
-      return ""
+      return "", ""
    end
 
    local page_env = view.env
 
+   local original_texts = {}
+   for _, item in pairs(page_env.registry) do
+      if item.kind ~= "module" and item.text and item.text ~= "" then
+         table.insert(original_texts, { item, item.text })
+         item.text = rebase_headings(item.text, 3)
+      end
+   end
    local markdown = add_kind_badges(
    MarkdownGenerator.render(page_env, resolver, false),
    page_env)
 
+   for _, entry in ipairs(original_texts) do
+      entry[1].text = entry[2]
+   end
 
    for item_path, examples in pairs(attached_examples or {}) do
       local anchor = '<a id="' .. item_path .. '"></a>'
@@ -223,27 +388,21 @@ function SiteApi.markdown(
       end
    end
 
-   local module_anchor = '<a id="' .. view.public .. '"></a>'
-   local _, ending = markdown:find(module_anchor, 1, true)
-   if ending then
-      markdown = markdown:sub(ending + 1)
+   local public_anchor = '<a id="' .. view.public .. '"></a>'
+   local _, public_end = markdown:find(public_anchor, 1, true)
+   if public_end then
+      markdown = markdown:sub(public_end + 1)
    end
+   local module_item = page_env.registry["$" .. view.public]
+   local introduction = module_item and module_item.text and
+   rebase_headings(module_item.text, 2) or
+   ""
    markdown = "\n" .. markdown
    markdown = markdown:gsub("\n(##+) ", function(level)
       return "\n" .. string.rep("#", math.min(#level + 1, 6)) .. " "
    end)
-   return markdown:sub(2)
+   return group_details(markdown:sub(2), view), introduction
 end
-
-
-
-
-local FUNCTION_KINDS = {
-   ["function"] = true,
-   method = true,
-   metamethod = true,
-   macro = true,
-}
 
 local function item_text(item, env)
    if item.text and item.text ~= "" then
@@ -259,9 +418,13 @@ local function item_text(item, env)
 end
 
 local function item_summary(item, env)
+   local prefix = item.kind == "variable" and
+   item.is_const and
+   "`<const>` " or
+   ""
    local text = item_text(item, env)
    if text == "" then
-      return "—"
+      return prefix .. "—"
    end
    text = text:gsub("```[%s%S]-```", " ")
    text = text:gsub("%[([^%]]+)%]%([^%)]+%)", "%1")
@@ -271,14 +434,25 @@ local function item_summary(item, env)
    text = text:gsub("^%s*#+%s*", "")
    text = text:gsub("%s+", " "):gsub("^%s+", ""):gsub("%s+$", "")
 
+   local sentences = 1
+   if text:match("^Read%-only%.%s") or
+      text:match("^Caller%-writable%.%s") or
+      text:match("^Engine%-owned%.%s") then
+
+      sentences = 2
+   end
+   local found = 0
    for index = 1, #text do
       local character = text:sub(index, index)
       local following = text:sub(index + 1, index + 1)
       if (character == "." or character == "!" or character == "?") and
          (following == "" or following:match("%s")) then
 
-         text = text:sub(1, index)
-         break
+         found = found + 1
+         if found == sentences then
+            text = text:sub(1, index)
+            break
+         end
       end
    end
 
@@ -288,7 +462,7 @@ local function item_summary(item, env)
       shortened = shortened:match("^(.*)%s+%S*$") or shortened
       text = shortened:gsub("%s+$", "") .. "..."
    end
-   return (text:gsub("\\", "\\\\"):gsub("|", "\\|"))
+   return prefix .. (text:gsub("\\", "\\\\"):gsub("|", "\\|"))
 end
 
 function SiteApi.summary(
@@ -356,7 +530,7 @@ function SiteApi.summary(
          if #output > 0 then
             table.insert(output, "\n")
          end
-         table.insert(output, "### " .. heading .. "\n\n")
+         table.insert(output, "**" .. heading .. "**\n\n")
          if show_kind then
             table.insert(
             output,

--- a/build/tealdoc/generator/site/view.lua
+++ b/build/tealdoc/generator/site/view.lua
@@ -193,6 +193,7 @@ local function same_public_item(
       right.kind == "variable" then
 
       return left.typename == right.typename and
+      left.is_const == right.is_const and
       summary_line(left) == summary_line(right)
    end
    local left_target = canonical_alias(left, env)
@@ -228,6 +229,7 @@ function SiteView.prepare(
    local source_paths = {}
    local mounted_from = {}
    local root_children = {}
+   local module_texts = {}
 
    local function mount(
       source_path,
@@ -323,6 +325,9 @@ function SiteView.prepare(
       env.registry["$" .. module_name],
       "configured API module not found: " .. module_name)
 
+      if module_item.text and module_item.text ~= "" then
+         table.insert(module_texts, module_item.text)
+      end
       local module_record = env.registry[module_name]
       local basename = module_name:match("([^.]+)$") or module_name
       local public_basename = public:match("([^.]+)$") or public
@@ -368,6 +373,9 @@ function SiteView.prepare(
       path = "$" .. public,
       name = public,
       children = { public },
+      text = #module_texts > 0 and
+      table.concat(module_texts, "\n\n") or
+      nil,
    }
    local public_root = {
       kind = "module",

--- a/build/tealdoc/parser/teal.lua
+++ b/build/tealdoc/parser/teal.lua
@@ -143,6 +143,33 @@ local function process_comments(comments, item, env)
    return #lines > 0
 end
 
+local function process_module_comment(
+   text,
+   item,
+   env)
+
+   local equals = text:match("^%-%-%[(=*)%[")
+   if equals == nil then
+      return
+   end
+
+   local opening_end = 4 + #equals
+   local closing = text:find(
+   "]" .. equals .. "]",
+   opening_end + 1,
+   true)
+
+   if not closing then
+      return
+   end
+
+   local body = text:sub(opening_end + 1, closing - 1):
+   gsub("^\r?\n", ""):
+   gsub("\r?\n$", "")
+   CommentParser.parse_text(body, item, env)
+   env.documented_items[item] = true
+end
+
 
 
 local function typeinfo_to_string(typeinfo)
@@ -354,7 +381,8 @@ end
 local function get_path(item, state, typ)
    assert(item.name)
    if typ and typ.typeid == state.module_item_typeid then
-      state.env.registry["$" .. state.module_name].text = item.text
+      local module_item = state.env.registry["$" .. state.module_name]
+      module_item.text = module_item.text or item.text
       return state.module_name
    end
    return state.path .. item.name
@@ -672,9 +700,12 @@ local function variable_declarations_visitor(node, state)
             state)
 
          else
+            local name_values = name
+            local name_attribute = name_values["attribute"]
             local variable_item = {
                kind = "variable",
                typename = typename,
+               is_const = name_attribute == "const" and true or nil,
                visibility = node.kind == "local_declaration" and "local" or "global",
                location = location_for_node(name),
             }
@@ -1385,6 +1416,7 @@ function TealParser:process(text, path, env)
    }
    table.insert(env.modules, module_name)
    env.registry[module_item.path] = module_item
+   process_module_comment(text, module_item, env)
    visit_node(result.ast, state)
 end
 

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -385,11 +385,71 @@ describe("Site generator", function()
         -- reaches the page if the row it was written into kept it out of the way.
         assert.is_truthy(html:find("<th>Name</th>", 1, true), html)
         assert.is_truthy(html:find(
+            "<td><code>name</code></td>",
+            1,
+            true
+        ), html)
+        assert.is_truthy(html:find(
             "<td><code>string | nil</code></td>",
             1,
             true
         ), html)
 
+        remove_tree(output)
+    end)
+
+    it("marks projected const variables in module summaries", function()
+        local env = DefaultEnv.init()
+        env.no_warnings_on_missing = true
+        tealdoc.process_text([[
+            --- Returns the build identifier.
+            global Build <const>: string = "dev"
+            return Build
+        ]], "Build.tl", env)
+        tealdoc.process_text([[
+            --- Returns the current status.
+            global Status: string = "ready"
+            return Status
+        ]], "Status.tl", env)
+
+        local output = os.tmpname()
+        os.remove(output)
+        SiteGenerator.build(output, env, {
+            title = "Constants",
+            pages = {
+                {path = "", title = "Home"},
+                {
+                    path = "constants",
+                    title = "Constants",
+                    api = {"Build", "Status"},
+                    public = "api",
+                },
+            },
+        })
+
+        local markdown = read_file(output .. "/constants.md")
+        assert.is_truthy(markdown:find("## Module contents", 1, true), markdown)
+        assert.is_truthy(markdown:find(
+            "| [`Build`](/constants/#api.Build) | " ..
+                '<span class="tealdoc-kind-badge tealdoc-kind-variable">' ..
+                "variable</span> | `<const>` Returns the build identifier. |",
+            1,
+            true
+        ), markdown)
+        assert.is_truthy(markdown:find(
+            "| [`Status`](/constants/#api.Status) | " ..
+                '<span class="tealdoc-kind-badge tealdoc-kind-variable">' ..
+                "variable</span> | Returns the current status. |",
+            1,
+            true
+        ), markdown)
+        assert.is_falsy(markdown:find(
+            "| [`Status`](/constants/#api.Status) | " ..
+                '<span class="tealdoc-kind-badge tealdoc-kind-variable">' ..
+                "variable</span> | `<const>`",
+            1,
+            true
+        ))
         remove_tree(output)
     end)
 
@@ -660,29 +720,54 @@ describe("Site generator", function()
 
             return Window
         ]], "window.tl", env)
-        tealdoc.process_text([[
-            local type Window = require("window")
-            local record api
-                record Options
-                    window: Window
-                end
+        tealdoc.process_text([==[--[=[
+Opens windows and reports display changes.
 
-                --- Opens a window.
-                --- @param options Window options.
-                open: function(options: Options)
+# Display changes
 
-                --- Shows a [`Window`](tealdoc:Window).
-                --- @param window Parent window.
-                messageBox: function(window: Window)
+It keeps wrapped prose
+on adjacent source lines.
 
-                --- Resets this API after clearing every cached value, pending
-                --- operation, registered listener, and retained handle so a
-                --- caller can start again from a completely clean state.
-                reset: function(self: api)
-            end
+```teal
+# This remains example code.
+local options = {}
+local window = api.open(options)
+```
+]=]
 
-            return api
-        ]], "api.tl", env)
+local type Window = require("window")
+local record api
+    --- Read-only. Reports the number of windows awaiting an event.
+    pending: integer
+
+    record Options
+        window: Window
+    end
+
+    --- Opens a window.
+    ---
+    --- ## Window lifetime
+    ---
+    --- The caller owns the returned window.
+    ---
+    --- ```teal
+    --- # This remains example code.
+    --- ```
+    --- @param options Window options.
+    open: function(options: Options)
+
+    --- Shows a [`Window`](tealdoc:Window).
+    --- @param window Parent window.
+    messageBox: function(window: Window)
+
+    --- Resets this API after clearing every cached value, pending
+    --- operation, registered listener, and retained handle so a
+    --- caller can start again from a completely clean state.
+    reset: function(self: api)
+end
+
+return api
+]==], "api.tl", env)
 
         local output = os.tmpname()
         os.remove(output)
@@ -909,6 +994,7 @@ print(value)
         local llms_full = read_file(output .. "/llms-full.txt")
         local manifest = read_file(output .. "/.tealdoc-manifest")
         local window_html = read_file(output .. "/modules/window/index.html")
+        local window_markdown = read_file(output .. "/modules/window.md")
         local redirect = read_file(output .. "/old-api.html")
         local example_html = read_file(output .. "/examples/answer/index.html")
         local not_found = read_file(output .. "/404.html")
@@ -1105,10 +1191,87 @@ print(value)
         ))
         assert.is_truthy(api:find("<h3", 1, true))
         assert.is_truthy(api:find("<h4", 1, true))
+        assert.is_truthy(markdown:find("## Module contents", 1, true))
         assert.is_falsy(api:find("Public APIs in", 1, true))
         assert.is_falsy(api:find("Every public item", 1, true))
         assert.is_truthy(api:find("<th>Function</th>", 1, true), api)
-        assert.is_truthy(markdown:find("### Functions", 1, true), markdown)
+        assert.is_truthy(markdown:find("**Functions**", 1, true), markdown)
+        assert.is_truthy(markdown:find(
+            "Read-only. Reports the number of windows awaiting an event.",
+            1,
+            true
+        ), markdown)
+        assert.is_falsy(markdown:find(
+            "| [`pending`](/modules/api/#api.pending) | " ..
+                '<span class="tealdoc-kind-badge tealdoc-kind-variable">' ..
+                "variable</span> | `<const>`",
+            1,
+            true
+        ))
+        local introduction_at = assert(markdown:find(
+            "Opens windows and reports display changes.",
+            1,
+            true
+        ))
+        local type_summary_at = assert(markdown:find("**Types**", 1, true))
+        local function_summary_at = assert(markdown:find(
+            "**Functions**",
+            1,
+            true
+        ))
+        local types_at = assert(markdown:find("## Types", type_summary_at, true))
+        local functions_at = assert(markdown:find(
+            "## Functions",
+            function_summary_at,
+            true
+        ))
+        assert.is_true(introduction_at < types_at)
+        assert.is_true(introduction_at < functions_at)
+        assert.is_true(type_summary_at < types_at)
+        assert.is_true(function_summary_at < functions_at)
+        assert.is_truthy(markdown:find("\n## Display changes\n", 1, true))
+        assert.is_truthy(
+            markdown:find("\n#### Window lifetime\n", 1, true),
+            markdown
+        )
+        assert.is_truthy(markdown:find(
+            "\n### api.Options ",
+            types_at,
+            true
+        ))
+        assert.is_truthy(markdown:find(
+            "\n### api.open ",
+            functions_at,
+            true
+        ))
+        assert.is_truthy(markdown:find(
+            "\n## Values\n",
+            functions_at,
+            true
+        ))
+        assert.is_truthy(markdown:find(
+            "\n### api.pending ",
+            functions_at,
+            true
+        ))
+        assert.is_falsy(markdown:find("\n### Types\n", 1, true))
+        assert.is_falsy(markdown:find("\n### Functions\n", 1, true))
+        assert.is_truthy(markdown:find(
+            "It keeps wrapped prose\non adjacent source lines.",
+            introduction_at,
+            true
+        ), markdown)
+        assert.is_truthy(markdown:find(
+            "```teal\n# This remains example code.\n" ..
+                "local options = {}\nlocal window = api.open(options)\n```",
+            introduction_at,
+            true
+        ), markdown)
+        assert.is_truthy(markdown:find(
+            "```teal\n# This remains example code.\n```",
+            functions_at,
+            true
+        ), markdown)
         -- The functions table carries no kind column, so a row goes straight
         -- from the name to the description.
         assert.is_truthy(markdown:find(
@@ -1157,7 +1320,8 @@ print(value)
             1,
             true
         ))
-        assert.is_truthy(api:find("api Reference", 1, true))
+        assert.is_falsy(api:find("api Reference", 1, true))
+        assert.are.equal(1, select(2, api:gsub("<h1[%s>]", "")))
         assert.is_truthy(api:find("Open a checked value", 1, true), api)
         assert.is_truthy(api:find(
             'tealdoc-token-string">&quot;checked&quot;</span>',
@@ -1166,12 +1330,15 @@ print(value)
         ), api)
         assert.is_falsy(api:find("#region", 1, true), api)
         assert.is_falsy(api:find("Public APIs in", 1, true))
-        assert.is_truthy(window_html:find("window Reference", 1, true))
+        assert.is_falsy(window_html:find("window Reference", 1, true))
+        assert.is_falsy(window_markdown:find("## Module contents", 1, true))
         assert.is_truthy(window_html:find(
-            "Public APIs in <code>window</code>.",
+            '<h1 id="window"',
             1,
             true
-        ))
+        ), window_html)
+        assert.are.equal(1, select(2, window_html:gsub("<h1[%s>]", "")))
+        assert.is_truthy(window_markdown:match("^# window\n"))
         assert.is_truthy(api:find(
             '<a class="tealdoc-footer-llms" href="/modules/api/llms.txt">llms.txt</a>',
             1,
@@ -1562,7 +1729,7 @@ print(value)
             true
         ))
         assert.is_truthy(css:find("text-overflow: ellipsis", 1, true))
-        assert.is_truthy(api:find('title="api Reference"', 1, true), api)
+        assert.is_falsy(api:find('title="api Reference"', 1, true), api)
         assert.is_truthy(css:find(
             "box-shadow: -100vw 0 0 100vw var(--tealdoc-sidebar-background)",
             1,
@@ -1660,7 +1827,7 @@ print(value)
         assert.is_truthy(llms_full:find("## Home", 1, true), llms_full)
         assert.is_truthy(llms_full:find("One thread", 1, true), llms_full)
         assert.is_truthy(llms_full:find("## API", 1, true), llms_full)
-        assert.is_truthy(llms_full:find("api Reference", 1, true), llms_full)
+        assert.is_falsy(llms_full:find("api Reference", 1, true), llms_full)
         assert.is_truthy(manifest:find(
             "tealdoc-manifest-v1\n",
             1,

--- a/spec/parser/teal/modules_spec.lua
+++ b/spec/parser/teal/modules_spec.lua
@@ -18,4 +18,31 @@ describe("teal support in tealdoc: modules", function()
             }
         })
     end)
+
+    it("reads a file-leading long comment as module documentation", function()
+        local registry = util.registry_for_text([[
+--[=[
+Opens windows and reports display changes.
+
+```teal
+local window = api.open()
+```
+]=]
+
+local dependency = require("dependency")
+local record test
+    dependency: dependency
+end
+return test
+]])
+
+        assert.are.equal(
+            [[Opens windows and reports display changes.
+
+```teal
+local window = api.open()
+```]],
+            registry["$test"].text
+        )
+    end)
 end)

--- a/spec/parser/teal/variables_spec.lua
+++ b/spec/parser/teal/variables_spec.lua
@@ -89,6 +89,46 @@ describe("teal support in tealdoc: variables", function()
         })
     end)
 
+    it("records const attributes on local and global variables", function()
+        util.check_registry([[
+            --- Local constant.
+            local localValue <const>: integer = 42
+            --- Global constant.
+            global GLOBAL_VALUE <const>: integer = 43
+        ]], {
+            ["$test~localValue"] = {
+                kind = "variable",
+                typename = "integer",
+                is_const = true,
+                name = "localValue",
+                text = "Local constant.",
+                visibility = "local",
+                parent = "$test",
+                path = "$test~localValue",
+                location = {
+                    filename = "test.tl",
+                    y = 2,
+                    x = 7,
+                },
+            },
+            ["$test~GLOBAL_VALUE"] = {
+                kind = "variable",
+                typename = "integer",
+                is_const = true,
+                name = "GLOBAL_VALUE",
+                text = "Global constant.",
+                visibility = "global",
+                parent = "$test",
+                path = "$test~GLOBAL_VALUE",
+                location = {
+                    filename = "test.tl",
+                    y = 4,
+                    x = 8,
+                },
+            },
+        })
+    end)
+
     it("should parse multiple variables in a single declaration", function()
         util.check_registry([[
             --- my variables

--- a/src/tealdoc.tl
+++ b/src/tealdoc.tl
@@ -276,6 +276,9 @@ local record tealdoc
 
         --- The name of the type of the variable.
         typename: string
+        --- Whether a local or global declaration carries the Teal `<const>`
+        --- attribute. Record fields leave this unset.
+        is_const: boolean
     end
 
     --- This record represents a type item in Tealdoc.

--- a/src/tealdoc/comment_parser.tl
+++ b/src/tealdoc/comment_parser.tl
@@ -7,8 +7,8 @@ end
 
 function CommentParser.parse_text(text: string, item: tealdoc.Item, env: tealdoc.Env)
     local lines = {}
-    for line in text:gmatch("[^\n]*") do
-        table.insert(lines, line)
+    for line in (text .. "\n"):gmatch("(.-)\n") do
+        table.insert(lines, (line:gsub("\r$", "")))
     end
     CommentParser.parse_lines(lines, item, env)
 end

--- a/src/tealdoc/generator/site.tl
+++ b/src/tealdoc/generator/site.tl
@@ -1589,7 +1589,7 @@ local function submodule_summary(
     end)
 
     local output: {string} = {
-        "### Submodules\n\n",
+        "**Submodules**\n\n",
         "| Submodule | Description |\n",
         "| --- | --- |\n",
     }
@@ -1618,26 +1618,29 @@ local function render_page(
     used_examples: {string: boolean}
 ): string, {SearchEntry}, string
     local markdown = SiteApi.source_markdown(page)
-    local api = SiteApi.markdown(
+    local api, module_introduction = SiteApi.markdown(
         view,
         resolver,
         attached_examples,
         used_examples
     )
-    if api ~= "" then
+    if view then
         local summary = submodule_summary(page, context, context.settings.base) ..
             SiteApi.summary(view, resolver)
-        local introduction = ""
+        if summary ~= "" then
+            summary = "## Module contents\n\n" .. summary
+        end
         local public_name = view.public
         if not markdown:match("%S") then
-            introduction = "\n\nPublic APIs in `" .. public_name .. "`."
+            markdown = "# " .. public_name
         end
         markdown = markdown ..
-            "\n\n## " ..
-            public_name ..
-            " Reference" ..
-            introduction ..
             "\n\n" ..
+            (
+                module_introduction ~= ""
+                    and module_introduction .. "\n\n"
+                    or ""
+            ) ..
             summary ..
             "\n" ..
             api

--- a/src/tealdoc/generator/site/api.tl
+++ b/src/tealdoc/generator/site/api.tl
@@ -15,7 +15,7 @@ local record SiteApi
         resolver: MarkdownGenerator.URLResolver,
         attached_examples: {string: {SiteTypes.PreparedExample}},
         used_examples: {string: boolean}
-    ): string
+    ): string, string
     summary: function(
         view: SiteTypes.ApiView,
         resolver: MarkdownGenerator.URLResolver
@@ -145,6 +145,79 @@ function SiteApi.type_links(
     return links
 end
 
+-- The kinds `Generator.item_kind` answers for something a caller calls. What
+-- is left over after these and the types is a value: a field, a variable, an
+-- enum member.
+local FUNCTION_KINDS: {string: boolean} = {
+    ["function"] = true,
+    method = true,
+    metamethod = true,
+    macro = true,
+}
+
+local function rebase_headings(text: string, target: integer): string
+    local lines: {string} = {}
+    for line in (text .. "\n"):gmatch("(.-)\n") do
+        table.insert(lines, (line:gsub("\r$", "")))
+    end
+
+    local shallowest: integer
+    local fence_character: string
+    local fence_length = 0
+    for _, line in ipairs(lines) do
+        local fence = line:match("^%s*(```+)")
+            or line:match("^%s*(~~~+)")
+        if fence then
+            local character = fence:sub(1, 1)
+            if not fence_character then
+                fence_character = character
+                fence_length = #fence
+            elseif character == fence_character and #fence >= fence_length then
+                fence_character = nil
+                fence_length = 0
+            end
+        elseif not fence_character then
+            local hashes = line:match("^%s*(#+)%s+")
+            if hashes and #hashes <= 6
+                and (not shallowest or #hashes < shallowest)
+            then
+                shallowest = #hashes
+            end
+        end
+    end
+    if not shallowest then
+        return text
+    end
+
+    local shift = target - shallowest
+    fence_character = nil
+    fence_length = 0
+    for index, line in ipairs(lines) do
+        local fence = line:match("^%s*(```+)")
+            or line:match("^%s*(~~~+)")
+        if fence then
+            local character = fence:sub(1, 1)
+            if not fence_character then
+                fence_character = character
+                fence_length = #fence
+            elseif character == fence_character and #fence >= fence_length then
+                fence_character = nil
+                fence_length = 0
+            end
+        elseif not fence_character then
+            local indentation, hashes, rest =
+                line:match("^(%s*)(#+)(%s+.*)$")
+            if hashes and #hashes <= 6 then
+                local level = math.min(6, #hashes + shift)
+                lines[index] = indentation ..
+                    string.rep("#", level) ..
+                    rest
+            end
+        end
+    end
+    return table.concat(lines, "\n")
+end
+
 local function add_kind_badges(markdown: string, env: tealdoc.Env): string
     for path, item in pairs(env.registry) do
         if item.kind ~= "module" and Generator.filter(item, env) then
@@ -173,22 +246,114 @@ local function add_kind_badges(markdown: string, env: tealdoc.Env): string
     return markdown
 end
 
+local function group_details(
+    markdown: string,
+    view: SiteTypes.ApiView
+): string
+    local env = view.env
+    local module = env.registry[view.public]
+    if not module or not module.children then
+        return ""
+    end
+
+    local positioned: {{tealdoc.Item, integer}} = {}
+    for _, path in ipairs(module.children) do
+        local item = env.registry[path]
+        if item and Generator.filter(item, env) then
+            local anchor = '<a id="' .. path .. '"></a>'
+            local start = markdown:find(anchor, 1, true)
+            if start then
+                table.insert(positioned, {item, start})
+            end
+        end
+    end
+    table.sort(
+        positioned,
+        function(
+            left: {tealdoc.Item, integer},
+            right: {tealdoc.Item, integer}
+        ): boolean
+            return left[2] < right[2]
+        end
+    )
+
+    local details: {string: string} = {}
+    for index, entry in ipairs(positioned) do
+        local ending = index < #positioned
+            and positioned[index + 1][2] - 1
+            or #markdown
+        details[entry[1].path] = markdown:sub(entry[2], ending)
+            :gsub("^%s+", "")
+            :gsub("%s+$", "")
+    end
+
+    local items: {tealdoc.Item} = {}
+    for _, entry in ipairs(positioned) do
+        table.insert(items, entry[1])
+    end
+    table.sort(items, function(a: tealdoc.Item, b: tealdoc.Item): boolean
+        local left = a.name:lower()
+        local right = b.name:lower()
+        if left == right then
+            return a.path < b.path
+        end
+        return left < right
+    end)
+
+    local groups: {{string, {tealdoc.Item}}} = {
+        { "Types", {} },
+        { "Functions", {} },
+        { "Values", {} },
+    }
+    for _, item in ipairs(items) do
+        local kind = Generator.item_kind(item, env)
+        local group = 3
+        if FUNCTION_KINDS[kind] then
+            group = 2
+        elseif item is tealdoc.TypeItem then
+            group = 1
+        end
+        table.insert(groups[group][2], item)
+    end
+
+    local output: {string} = {}
+    for _, group in ipairs(groups) do
+        if #group[2] > 0 then
+            table.insert(output, "## " .. group[1])
+            for _, item in ipairs(group[2]) do
+                table.insert(output, details[item.path])
+            end
+        end
+    end
+    return table.concat(output, "\n\n")
+end
+
 function SiteApi.markdown(
     view: SiteTypes.ApiView,
     resolver: MarkdownGenerator.URLResolver,
     attached_examples: {string: {SiteTypes.PreparedExample}},
     used_examples: {string: boolean}
-): string
+): string, string
     if not view then
-        return ""
+        return "", ""
     end
 
     local page_env = view.env
 
+    local original_texts: {{tealdoc.Item, string}} = {}
+    for _, item in pairs(page_env.registry) do
+        if item.kind ~= "module" and item.text and item.text ~= "" then
+            table.insert(original_texts, {item, item.text})
+            item.text = rebase_headings(item.text, 3)
+        end
+    end
     local markdown = add_kind_badges(
         MarkdownGenerator.render(page_env, resolver, false),
         page_env
     )
+    for _, entry in ipairs(original_texts) do
+        entry[1].text = entry[2]
+    end
 
     for item_path, examples in pairs(attached_examples or {}) do
         local anchor = '<a id="' .. item_path .. '"></a>'
@@ -223,27 +388,21 @@ function SiteApi.markdown(
         end
     end
 
-    local module_anchor = '<a id="' .. view.public .. '"></a>'
-    local _, ending = markdown:find(module_anchor, 1, true)
-    if ending then
-        markdown = markdown:sub(ending + 1)
+    local public_anchor = '<a id="' .. view.public .. '"></a>'
+    local _, public_end = markdown:find(public_anchor, 1, true)
+    if public_end then
+        markdown = markdown:sub(public_end + 1)
     end
+    local module_item = page_env.registry["$" .. view.public]
+    local introduction = module_item and module_item.text
+        and rebase_headings(module_item.text, 2)
+        or ""
     markdown = "\n" .. markdown
     markdown = markdown:gsub("\n(##+) ", function(level: string): string
         return "\n" .. string.rep("#", math.min(#level + 1, 6)) .. " "
     end)
-    return markdown:sub(2)
+    return group_details(markdown:sub(2), view), introduction
 end
-
--- The kinds `Generator.item_kind` answers for something a caller calls. What
--- is left over after these and the types is a value: a field, a variable, an
--- enum member.
-local FUNCTION_KINDS: {string: boolean} = {
-    ["function"] = true,
-    method = true,
-    metamethod = true,
-    macro = true,
-}
 
 local function item_text(item: tealdoc.Item, env: tealdoc.Env): string
     if item.text and item.text ~= "" then
@@ -259,9 +418,13 @@ local function item_text(item: tealdoc.Item, env: tealdoc.Env): string
 end
 
 local function item_summary(item: tealdoc.Item, env: tealdoc.Env): string
+    local prefix = item is tealdoc.VariableItem
+        and item.is_const
+        and "`<const>` "
+        or ""
     local text = item_text(item, env)
     if text == "" then
-        return "—"
+        return prefix .. "—"
     end
     text = text:gsub("```[%s%S]-```", " ")
     text = text:gsub("%[([^%]]+)%]%([^%)]+%)", "%1")
@@ -271,14 +434,25 @@ local function item_summary(item: tealdoc.Item, env: tealdoc.Env): string
     text = text:gsub("^%s*#+%s*", "")
     text = text:gsub("%s+", " "):gsub("^%s+", ""):gsub("%s+$", "")
 
+    local sentences = 1
+    if text:match("^Read%-only%.%s")
+        or text:match("^Caller%-writable%.%s")
+        or text:match("^Engine%-owned%.%s")
+    then
+        sentences = 2
+    end
+    local found = 0
     for index = 1, #text do
         local character = text:sub(index, index)
         local following = text:sub(index + 1, index + 1)
         if (character == "." or character == "!" or character == "?")
             and (following == "" or following:match("%s"))
         then
-            text = text:sub(1, index)
-            break
+            found = found + 1
+            if found == sentences then
+                text = text:sub(1, index)
+                break
+            end
         end
     end
 
@@ -288,7 +462,7 @@ local function item_summary(item: tealdoc.Item, env: tealdoc.Env): string
         shortened = shortened:match("^(.*)%s+%S*$") or shortened
         text = shortened:gsub("%s+$", "") .. "..."
     end
-    return (text:gsub("\\", "\\\\"):gsub("|", "\\|"))
+    return prefix .. (text:gsub("\\", "\\\\"):gsub("|", "\\|"))
 end
 
 function SiteApi.summary(
@@ -356,7 +530,7 @@ function SiteApi.summary(
             if #output > 0 then
                 table.insert(output, "\n")
             end
-            table.insert(output, "### " .. heading .. "\n\n")
+            table.insert(output, "**" .. heading .. "**\n\n")
             if show_kind then
                 table.insert(
                     output,

--- a/src/tealdoc/generator/site/view.tl
+++ b/src/tealdoc/generator/site/view.tl
@@ -193,6 +193,7 @@ local function same_public_item(
         and right is tealdoc.VariableItem
     then
         return left.typename == right.typename
+            and left.is_const == right.is_const
             and summary_line(left) == summary_line(right)
     end
     local left_target = canonical_alias(left, env)
@@ -228,6 +229,7 @@ function SiteView.prepare(
     local source_paths: {string} = {}
     local mounted_from: {string: string} = {}
     local root_children: {string} = {}
+    local module_texts: {string} = {}
 
     local function mount(
         source_path: string,
@@ -323,6 +325,9 @@ function SiteView.prepare(
             env.registry["$" .. module_name],
             "configured API module not found: " .. module_name
         )
+        if module_item.text and module_item.text ~= "" then
+            table.insert(module_texts, module_item.text)
+        end
         local module_record = env.registry[module_name]
         local basename = module_name:match("([^.]+)$") or module_name
         local public_basename = public:match("([^.]+)$") or public
@@ -368,6 +373,9 @@ function SiteView.prepare(
         path = "$" .. public,
         name = public,
         children = {public},
+        text = #module_texts > 0
+            and table.concat(module_texts, "\n\n")
+            or nil,
     }
     local public_root: tealdoc.Item = {
         kind = "module",

--- a/src/tealdoc/parser/teal.tl
+++ b/src/tealdoc/parser/teal.tl
@@ -143,6 +143,33 @@ local function process_comments(comments: {tl.Comment}, item: tealdoc.Item, env:
     return #lines > 0
 end
 
+local function process_module_comment(
+    text: string,
+    item: tealdoc.Item,
+    env: tealdoc.Env
+)
+    local equals = text:match("^%-%-%[(=*)%[")
+    if equals == nil then
+        return
+    end
+
+    local opening_end = 4 + #equals
+    local closing = text:find(
+        "]" .. equals .. "]",
+        opening_end + 1,
+        true
+    )
+    if not closing then
+        return
+    end
+
+    local body = text:sub(opening_end + 1, closing - 1)
+        :gsub("^\r?\n", "")
+        :gsub("\r?\n$", "")
+    CommentParser.parse_text(body, item, env)
+    env.documented_items[item] = true
+end
+
 
 -- TODO: temporary for now?
 local function typeinfo_to_string(typeinfo: tl.TypeInfo): string
@@ -354,7 +381,8 @@ end
 local function get_path(item: tealdoc.Item, state: VisitState, typ?: tl.Type): string
     assert(item.name)
     if typ and typ.typeid == state.module_item_typeid then
-        state.env.registry["$"..state.module_name].text = item.text
+        local module_item = state.env.registry["$"..state.module_name]
+        module_item.text = module_item.text or item.text
         return state.module_name
     end
     return state.path..item.name
@@ -672,9 +700,12 @@ local function variable_declarations_visitor(node: tl.Node, state: VisitState)
                     state
                 )
             else
+                local name_values = name as {string: any}
+                local name_attribute = name_values["attribute"] as string
                 local variable_item = {
                     kind = "variable",
                     typename = typename,
+                    is_const = name_attribute == "const" and true or nil,
                     visibility = node.kind == "local_declaration" and "local" or "global",
                     location = location_for_node(name)
                 }
@@ -1385,6 +1416,7 @@ function TealParser:process(text: string, path: string, env: tealdoc.Env)
     }
     table.insert(env.modules, module_name)
     env.registry[module_item.path] = module_item
+    process_module_comment(text, module_item, env)
     visit_node(result.ast, state)
 end
 


### PR DESCRIPTION
## Summary

- read a file-leading Teal long comment as module documentation
- place module documentation before generated API summaries and details
- group API summaries and symbol details into Types, Functions, and Values
- place nonempty summary tables under a Module contents section
- mark projected Teal `<const>` variables in summary descriptions
- keep one page H1 and remove the redundant Reference heading
- rebase authored Markdown headings without changing fenced code
- preserve ownership prefixes in summary descriptions

## Checks

- `make build`
- focused LuaJIT parser and site specs: 43 successes
- fresh application of the downstream patch against `a472e7d`
