### PR TITLE
Show functions before types in API details

### DIFF
--- a/build/tealdoc/generator/site/api.lua
+++ b/build/tealdoc/generator/site/api.lua
@@ -301,17 +301,17 @@ local function group_details(
    end)
 
    local groups = {
-      { "Types", {} },
       { "Functions", {} },
+      { "Types", {} },
       { "Values", {} },
    }
    for _, item in ipairs(items) do
       local kind = Generator.item_kind(item, env)
       local group = 3
       if FUNCTION_KINDS[kind] then
-         group = 2
-      elseif item.kind == "type" then
          group = 1
+      elseif item.kind == "type" then
+         group = 2
       end
       table.insert(groups[group][2], item)
    end
@@ -507,17 +507,17 @@ function SiteApi.summary(
 
 
    local groups = {
-      { "Types", "Type", true, {} },
       { "Functions", "Function", false, {} },
+      { "Types", "Type", true, {} },
       { "Values", "Value", true, {} },
    }
    for _, item in ipairs(items) do
       local kind = Generator.item_kind(item, env)
       local group = 3
       if FUNCTION_KINDS[kind] then
-         group = 2
-      elseif item.kind == "type" then
          group = 1
+      elseif item.kind == "type" then
+         group = 2
       end
       table.insert(groups[group][4], item)
    end

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -1227,8 +1227,10 @@ print(value)
         ))
         assert.is_true(introduction_at < types_at)
         assert.is_true(introduction_at < functions_at)
+        assert.is_true(function_summary_at < type_summary_at, markdown)
         assert.is_true(type_summary_at < types_at)
         assert.is_true(function_summary_at < functions_at)
+        assert.is_true(functions_at < types_at)
         assert.is_truthy(markdown:find("\n## Display changes\n", 1, true))
         assert.is_truthy(
             markdown:find("\n#### Window lifetime\n", 1, true),

--- a/src/tealdoc/generator/site/api.tl
+++ b/src/tealdoc/generator/site/api.tl
@@ -301,17 +301,17 @@ local function group_details(
     end)
 
     local groups: {{string, {tealdoc.Item}}} = {
-        { "Types", {} },
         { "Functions", {} },
+        { "Types", {} },
         { "Values", {} },
     }
     for _, item in ipairs(items) do
         local kind = Generator.item_kind(item, env)
         local group = 3
         if FUNCTION_KINDS[kind] then
-            group = 2
-        elseif item is tealdoc.TypeItem then
             group = 1
+        elseif item is tealdoc.TypeItem then
+            group = 2
         end
         table.insert(groups[group][2], item)
     end
@@ -507,17 +507,17 @@ function SiteApi.summary(
     -- `item_kind` names it, and the detail below carries the badge anyway, so
     -- a column there would repeat the heading on every row.
     local groups: {{string, string, boolean, {tealdoc.Item}}} = {
-        { "Types", "Type", true, {} },
         { "Functions", "Function", false, {} },
+        { "Types", "Type", true, {} },
         { "Values", "Value", true, {} },
     }
     for _, item in ipairs(items) do
         local kind = Generator.item_kind(item, env)
         local group = 3
         if FUNCTION_KINDS[kind] then
-            group = 2
-        elseif item is tealdoc.TypeItem then
             group = 1
+        elseif item is tealdoc.TypeItem then
+            group = 2
         end
         table.insert(groups[group][4], item)
     end


### PR DESCRIPTION
## Summary

- render function detail sections before type details
- keep the module contents tables in their existing order
- verify the generated order in the composed-site spec

Constructors are often the practical entry point into a module, so readers should reach them before the type details.

## Testing

- `busted spec/generator/site_spec.lua` (26 successes)