### PR TITLE
Project selected API declarations across namespaces

### DIFF
--- a/build/tealdoc/generator/site/config.lua
+++ b/build/tealdoc/generator/site/config.lua
@@ -131,6 +131,12 @@ local page_keys = {
    noindex = true,
 }
 
+local api_source_keys = {
+   module = true,
+   public = true,
+   include = true,
+}
+
 local example_keys = {
    path = true,
    attach_to = true,
@@ -420,7 +426,7 @@ function SiteConfig.configure(
       page["api"] == nil or
       type(page["api"]) == "string" or
       type(page["api"]) == "table",
-      name .. ".api must be a string or list of strings")
+      name .. ".api must be a string or list of API sources")
 
       if type(page["api"]) == "string" then
          assert(page["api"] ~= "", name .. ".api must not be empty")
@@ -432,21 +438,77 @@ function SiteConfig.configure(
          type(page["public"]) == "string" and page["public"] ~= "",
          name .. ".public is required when api contains several modules")
 
-         for module_index, module_name in ipairs(modules) do
-            assert(
-            type(module_name) == "string" and module_name ~= "",
-            name ..
+         for module_index, source_value in ipairs(modules) do
+            local source_name = name ..
             ".api[" ..
             tostring(module_index) ..
-            "] must be a non-empty string")
+            "]"
+            local module_name
+            local source_public = ""
+            if type(source_value) == "string" then
+               module_name = source_value
+               assert(
+               module_name ~= "",
+               source_name .. " must not be empty")
 
+            else
+               assert(
+               type(source_value) == "table",
+               source_name .. " must be a string or table")
+
+               validate_keys(
+               source_value,
+               api_source_keys,
+               source_name)
+
+               local source = source_value
+               assert(
+               type(source["module"]) == "string" and
+               source["module"] ~= "",
+               source_name .. ".module is required")
+
+               assert(
+               source["public"] == nil or
+               type(source["public"]) == "string" and
+               source["public"] ~= "",
+               source_name .. ".public must be a non-empty string")
+
+               assert(
+               source["include"] == nil or
+               type(source["include"]) == "table",
+               source_name .. ".include must be a list of names")
+
+               local names = {}
+               for include_index, include_name in ipairs(
+                  source["include"] or {}) do
+
+                  assert(
+                  type(include_name) == "string" and
+                  include_name ~= "",
+                  source_name ..
+                  ".include[" ..
+                  tostring(include_index) ..
+                  "] must be a non-empty string")
+
+                  assert(
+                  not names[include_name],
+                  source_name ..
+                  ".include contains duplicate name " ..
+                  tostring(include_name))
+
+                  names[include_name] = true
+               end
+               module_name = source["module"]
+               source_public = source["public"] or ""
+            end
+            local identity = module_name .. "\0" .. source_public
             assert(
-            not seen[module_name],
+            not seen[identity],
             name ..
-            ".api contains duplicate module " ..
+            ".api contains duplicate API source " ..
             tostring(module_name))
 
-            seen[module_name] = true
+            seen[identity] = true
          end
       end
       assert(

--- a/build/tealdoc/generator/site/types.lua
+++ b/build/tealdoc/generator/site/types.lua
@@ -1,6 +1,12 @@
 local tealdoc = require("tealdoc")
 
-local SiteTypes = { Link = {}, Feature = {}, HeadEntry = {}, Page = {}, SidebarItem = {}, Example = {}, Settings = {}, Context = {}, PreparedExample = {}, ApiView = {} }
+local SiteTypes = { ApiSource = {}, Link = {}, Feature = {}, HeadEntry = {}, Page = {}, SidebarItem = {}, Example = {}, Settings = {}, Context = {}, PreparedExample = {}, ApiView = {} }
+
+
+
+
+
+
 
 
 

--- a/build/tealdoc/generator/site/view.lua
+++ b/build/tealdoc/generator/site/view.lua
@@ -7,11 +7,27 @@ local SiteView = {}
 
 
 
-function SiteView.modules(page)
+local function sources(page)
    if type(page.api) == "string" then
-      return { page.api }
+      return { { module = page.api } }
    end
-   return page.api or {}
+   local output = {}
+   for _, entry in ipairs(page.api or {}) do
+      if type(entry) == "string" then
+         table.insert(output, { module = entry })
+      else
+         table.insert(output, entry)
+      end
+   end
+   return output
+end
+
+function SiteView.modules(page)
+   local output = {}
+   for _, source in ipairs(sources(page)) do
+      table.insert(output, source.module)
+   end
+   return output
 end
 
 local function copy_item(item)
@@ -211,11 +227,12 @@ function SiteView.prepare(
    page,
    env)
 
-   local modules = SiteView.modules(page)
-   if #modules == 0 then
+   local api_sources = sources(page)
+   if #api_sources == 0 then
       return nil
    end
-   local public = page.public or modules[1]
+   local modules = SiteView.modules(page)
+   local public = page.public or api_sources[1].public or modules[1]
    local projected = tealdoc.Env.init()
    for path, item in pairs(env.registry) do
       projected.registry[path] = item
@@ -320,44 +337,67 @@ function SiteView.prepare(
       return public_path
    end
 
-   for _, module_name in ipairs(modules) do
+   for _, source in ipairs(api_sources) do
+      local module_name = source.module
+      local source_public = source.public or public
       local module_item = assert(
       env.registry["$" .. module_name],
       "configured API module not found: " .. module_name)
 
-      if module_item.text and module_item.text ~= "" then
+      if #(source.include or {}) == 0 and
+         module_item.text and
+         module_item.text ~= "" then
+
          table.insert(module_texts, module_item.text)
       end
       local module_record = env.registry[module_name]
       local basename = module_name:match("([^.]+)$") or module_name
-      local public_basename = public:match("([^.]+)$") or public
+      local public_basename = source_public:match("([^.]+)$") or
+      source_public
       local mounts_as_child = module_record and
-      module_name ~= public and
+      module_name ~= source_public and
       basename ~= public_basename and
       basename:match("^[A-Z]") ~= nil
+      local included = {}
+      for _, name in ipairs(source.include or {}) do
+         included[name] = true
+      end
+      local function selected(child_path)
+         if #(source.include or {}) == 0 then
+            return true
+         end
+         local child = assert(env.registry[child_path])
+         return included[child.name] == true
+      end
       if mounts_as_child then
-         local mounted = mount(
-         module_name,
-         module_name,
-         public .. "." .. basename,
-         public,
-         true)
+         if selected(module_name) then
+            local mounted = mount(
+            module_name,
+            module_name,
+            source_public .. "." .. basename,
+            public,
+            true)
 
-         if mounted then
-            table.insert(root_children, mounted)
+            if mounted then
+               table.insert(root_children, mounted)
+            end
          end
       else
-         source_to_public[module_name] = public
+         if #(source.include or {}) == 0 then
+            source_to_public[module_name] = source_public
+         end
          local exported = module_record and module_record.children or
          module_item.children or
          {}
          for _, child_path in ipairs(exported) do
-            if not module_record or child_path ~= module_name then
+            if (not module_record or child_path ~= module_name) and
+               selected(child_path) then
+
                local child = assert(env.registry[child_path])
                local mounted = mount(
                child_path,
                child_path,
-               public .. "." .. child.name,
+               source_public .. "." .. child.name,
                public)
 
                if mounted then

--- a/build/tealdoc/parser/teal.lua
+++ b/build/tealdoc/parser/teal.lua
@@ -183,6 +183,23 @@ local function type_to_string(report, typ)
    return typeinfo_to_string(typeinfo_for_type(report, typ))
 end
 
+local function typearg_constraint_to_string(
+   report,
+   constraint)
+
+   if not constraint then
+      return nil
+   end
+   local reported = type_to_string(report, constraint)
+   local direct = tostring(constraint)
+   if reported and reported:match("^function<") and
+      not direct:match("^table:") then
+
+      return direct
+   end
+   return reported
+end
+
 local function type_references_for_type(typ, state)
    local references = {}
    local seen = {}
@@ -473,6 +490,7 @@ local function item_for_function_type(t, visibility, kind, state, owner)
       location = location_for_type(t),
    }
 
+   local is_generic = t.typename == "generic"
    if t.typename == "generic" then
       local base = t.t
       assert(base.typename == "function")
@@ -482,7 +500,10 @@ local function item_for_function_type(t, visibility, kind, state, owner)
          local normalized = typearg.typearg:gsub("@.*", "")
          item.typeargs[i] = {
             name = normalized,
-            constraint = typearg.constraint and type_to_string(state.type_report, typearg.constraint),
+            constraint = typearg_constraint_to_string(
+            state.type_report,
+            typearg.constraint),
+
          }
       end
 
@@ -494,7 +515,10 @@ local function item_for_function_type(t, visibility, kind, state, owner)
    if t.args and #t.args.tuple > 0 then
       item.params = {}
       for i, ar in ipairs(t.args.tuple) do
-         if t.is_method and i == 1 then
+         if i == 1 and
+            owner and
+            (t.is_method or is_generic and ar.typename == "self") then
+
 
 
 

--- a/docs/site_configuration.md
+++ b/docs/site_configuration.md
@@ -359,6 +359,11 @@ pages = {
             "my.components",
             "my.camera",
             "my.renderer",
+            {
+                module = "my.types",
+                public = "my",
+                include = { "World", "Query" },
+            },
         },
         public = "my.graphics",
     },
@@ -376,6 +381,11 @@ module's direct public children under that public namespace without changing
 the parsed registry. Compatible re-exports coalesce at the same public path;
 unrelated collisions fail the build. Type and alias links are emitted only for
 exact items rendered by a configured API page.
+
+An API source may be a table with `module`, `public`, and `include` fields.
+`public` overrides the page namespace for that source. `include` selects direct
+children by name. This lets one page document declarations that live together
+in source but occupy different public namespaces.
 
 Lowercase module basenames contribute their public children directly.
 Uppercase module basenames, conventionally record or class modules, retain that

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -318,6 +318,21 @@ describe("Site generator", function()
 
             return Camera
         ]], "Camera.tl", env)
+        tealdoc.process_text([[
+            local record types
+                --- A type published at another root.
+                record Root
+                    --- Copies this value.
+                    copy: function(self): Root
+                end
+
+                --- A type omitted from the projection.
+                record Hidden
+                end
+            end
+
+            return types
+        ]], "types.tl", env)
 
         local output = os.tmpname()
         os.remove(output)
@@ -331,7 +346,16 @@ describe("Site generator", function()
                 {
                     path = "api",
                     title = "Combined",
-                    api = {"first", "second", "Camera"},
+                    api = {
+                        "first",
+                        "second",
+                        "Camera",
+                        {
+                            module = "types",
+                            public = "public",
+                            include = {"Root"},
+                        },
+                    },
                     public = "public.api",
                 },
             },
@@ -347,6 +371,9 @@ describe("Site generator", function()
         assert.is_truthy(html:find('id="public.api.copy"', 1, true), html)
         assert.is_truthy(html:find('id="public.api.Camera"', 1, true), html)
         assert.is_truthy(html:find('id="public.api.Camera.x"', 1, true), html)
+        assert.is_truthy(html:find('id="public.Root"', 1, true), html)
+        assert.is_truthy(html:find('href="/api/#public.Root"', 1, true), html)
+        assert.is_falsy(html:find('id="public.Hidden"', 1, true))
         assert.is_falsy(html:find('id="public.api.x"', 1, true))
         assert.is_truthy(html:find('href="/api/#public.api.Widget"', 1, true), html)
         assert.is_falsy(html:find("#public.api.Secret", 1, true))

--- a/src/tealdoc/generator/site/config.tl
+++ b/src/tealdoc/generator/site/config.tl
@@ -131,6 +131,12 @@ local page_keys: {string: boolean} = {
     noindex = true,
 }
 
+local api_source_keys: {string: boolean} = {
+    module = true,
+    public = true,
+    include = true,
+}
+
 local example_keys: {string: boolean} = {
     path = true,
     attach_to = true,
@@ -420,7 +426,7 @@ function SiteConfig.configure(
             page["api"] == nil
                 or type(page["api"]) == "string"
                 or type(page["api"]) == "table",
-            name .. ".api must be a string or list of strings"
+            name .. ".api must be a string or list of API sources"
         )
         if type(page["api"]) == "string" then
             assert(page["api"] ~= "", name .. ".api must not be empty")
@@ -432,21 +438,77 @@ function SiteConfig.configure(
                 type(page["public"]) == "string" and page["public"] ~= "",
                 name .. ".public is required when api contains several modules"
             )
-            for module_index, module_name in ipairs(modules) do
+            for module_index, source_value in ipairs(modules) do
+                local source_name = name ..
+                    ".api[" ..
+                    tostring(module_index) ..
+                    "]"
+                local module_name: string
+                local source_public = ""
+                if type(source_value) == "string" then
+                    module_name = source_value as string
+                    assert(
+                        module_name ~= "",
+                        source_name .. " must not be empty"
+                    )
+                else
+                    assert(
+                        type(source_value) == "table",
+                        source_name .. " must be a string or table"
+                    )
+                    validate_keys(
+                        source_value,
+                        api_source_keys,
+                        source_name
+                    )
+                    local source = source_value as {string: any}
+                    assert(
+                        type(source["module"]) == "string"
+                            and source["module"] ~= "",
+                        source_name .. ".module is required"
+                    )
+                    assert(
+                        source["public"] == nil
+                            or type(source["public"]) == "string"
+                                and source["public"] ~= "",
+                        source_name .. ".public must be a non-empty string"
+                    )
+                    assert(
+                        source["include"] == nil
+                            or type(source["include"]) == "table",
+                        source_name .. ".include must be a list of names"
+                    )
+                    local names: {string: boolean} = {}
+                    for include_index, include_name in ipairs(
+                        source["include"] as {any} or {}
+                    ) do
+                        assert(
+                            type(include_name) == "string"
+                                and include_name ~= "",
+                            source_name ..
+                                ".include[" ..
+                                tostring(include_index) ..
+                                "] must be a non-empty string"
+                        )
+                        assert(
+                            not names[include_name as string],
+                            source_name ..
+                                ".include contains duplicate name " ..
+                                tostring(include_name)
+                        )
+                        names[include_name as string] = true
+                    end
+                    module_name = source["module"] as string
+                    source_public = source["public"] as string or ""
+                end
+                local identity = module_name .. "\0" .. source_public
                 assert(
-                    type(module_name) == "string" and module_name ~= "",
+                    not seen[identity],
                     name ..
-                        ".api[" ..
-                        tostring(module_index) ..
-                        "] must be a non-empty string"
-                )
-                assert(
-                    not seen[module_name as string],
-                    name ..
-                        ".api contains duplicate module " ..
+                        ".api contains duplicate API source " ..
                         tostring(module_name)
                 )
-                seen[module_name as string] = true
+                seen[identity] = true
             end
         end
         assert(

--- a/src/tealdoc/generator/site/types.tl
+++ b/src/tealdoc/generator/site/types.tl
@@ -1,6 +1,12 @@
 local tealdoc = require("tealdoc")
 
 local record SiteTypes
+    record ApiSource
+        module: string
+        public: string
+        include: {string}
+    end
+
     record Link
         text: string
         path: string
@@ -24,7 +30,7 @@ local record SiteTypes
         title: string
         description: string
         source: string
-        api: string | {string}
+        api: string | {string | ApiSource}
         public: string
         layout: string
         hero_title: string

--- a/src/tealdoc/generator/site/view.tl
+++ b/src/tealdoc/generator/site/view.tl
@@ -7,11 +7,27 @@ local record SiteView
     modules: function(page: SiteTypes.Page): {string}
 end
 
-function SiteView.modules(page: SiteTypes.Page): {string}
+local function sources(page: SiteTypes.Page): {SiteTypes.ApiSource}
     if type(page.api) == "string" then
-        return {page.api as string}
+        return {{module = page.api as string}}
     end
-    return page.api as {string} or {}
+    local output: {SiteTypes.ApiSource} = {}
+    for _, entry in ipairs(page.api as {string | SiteTypes.ApiSource} or {}) do
+        if type(entry) == "string" then
+            table.insert(output, {module = entry as string})
+        else
+            table.insert(output, entry as SiteTypes.ApiSource)
+        end
+    end
+    return output
+end
+
+function SiteView.modules(page: SiteTypes.Page): {string}
+    local output: {string} = {}
+    for _, source in ipairs(sources(page)) do
+        table.insert(output, source.module)
+    end
+    return output
 end
 
 local function copy_item(item: tealdoc.Item): tealdoc.Item
@@ -211,11 +227,12 @@ function SiteView.prepare(
     page: SiteTypes.Page,
     env: tealdoc.Env
 ): SiteTypes.ApiView
-    local modules = SiteView.modules(page)
-    if #modules == 0 then
+    local api_sources = sources(page)
+    if #api_sources == 0 then
         return nil
     end
-    local public = page.public or modules[1]
+    local modules = SiteView.modules(page)
+    local public = page.public or api_sources[1].public or modules[1]
     local projected = tealdoc.Env.init()
     for path, item in pairs(env.registry) do
         projected.registry[path] = item
@@ -320,44 +337,67 @@ function SiteView.prepare(
         return public_path
     end
 
-    for _, module_name in ipairs(modules) do
+    for _, source in ipairs(api_sources) do
+        local module_name = source.module
+        local source_public = source.public or public
         local module_item = assert(
             env.registry["$" .. module_name],
             "configured API module not found: " .. module_name
         )
-        if module_item.text and module_item.text ~= "" then
+        if #(source.include or {}) == 0
+            and module_item.text
+            and module_item.text ~= ""
+        then
             table.insert(module_texts, module_item.text)
         end
         local module_record = env.registry[module_name]
         local basename = module_name:match("([^.]+)$") or module_name
-        local public_basename = public:match("([^.]+)$") or public
+        local public_basename = source_public:match("([^.]+)$")
+            or source_public
         local mounts_as_child = module_record
-            and module_name ~= public
+            and module_name ~= source_public
             and basename ~= public_basename
             and basename:match("^[A-Z]") ~= nil
+        local included: {string: boolean} = {}
+        for _, name in ipairs(source.include or {}) do
+            included[name] = true
+        end
+        local function selected(child_path: string): boolean
+            if #(source.include or {}) == 0 then
+                return true
+            end
+            local child = assert(env.registry[child_path])
+            return included[child.name] == true
+        end
         if mounts_as_child then
-            local mounted = mount(
-                module_name,
-                module_name,
-                public .. "." .. basename,
-                public,
-                true
-            )
-            if mounted then
-                table.insert(root_children, mounted)
+            if selected(module_name) then
+                local mounted = mount(
+                    module_name,
+                    module_name,
+                    source_public .. "." .. basename,
+                    public,
+                    true
+                )
+                if mounted then
+                    table.insert(root_children, mounted)
+                end
             end
         else
-            source_to_public[module_name] = public
+            if #(source.include or {}) == 0 then
+                source_to_public[module_name] = source_public
+            end
             local exported = module_record and module_record.children
                 or module_item.children
                 or {}
             for _, child_path in ipairs(exported) do
-                if not module_record or child_path ~= module_name then
+                if (not module_record or child_path ~= module_name)
+                    and selected(child_path)
+                then
                     local child = assert(env.registry[child_path])
                     local mounted = mount(
                         child_path,
                         child_path,
-                        public .. "." .. child.name,
+                        source_public .. "." .. child.name,
                         public
                     )
                     if mounted then

--- a/src/tealdoc/parser/teal.tl
+++ b/src/tealdoc/parser/teal.tl
@@ -183,6 +183,23 @@ local function type_to_string(report: tl.TypeReport, typ: tl.Type): string
     return typeinfo_to_string(typeinfo_for_type(report, typ))
 end
 
+local function typearg_constraint_to_string(
+    report: tl.TypeReport,
+    constraint?: tl.Type
+): string
+    if not constraint then
+        return nil
+    end
+    local reported = type_to_string(report, constraint)
+    local direct = tostring(constraint)
+    if reported and reported:match("^function<")
+        and not direct:match("^table:")
+    then
+        return direct
+    end
+    return reported
+end
+
 local function type_references_for_type(typ: tl.Type, state: VisitState): {tealdoc.TypeReference}
     local references: {tealdoc.TypeReference} = {}
     local seen: {integer: boolean} = {}
@@ -473,6 +490,7 @@ local function item_for_function_type(t: tl.FunctionType | tl.GenericType, visib
         location = location_for_type(t)
     }
 
+    local is_generic = t is tl.GenericType
     if t is tl.GenericType then
         local base = t.t
         assert(base is tl.FunctionType)
@@ -482,7 +500,10 @@ local function item_for_function_type(t: tl.FunctionType | tl.GenericType, visib
             local normalized = typearg.typearg:gsub("@.*", "") -- ?
             item.typeargs[i] = {
                 name = normalized,
-                constraint = typearg.constraint and type_to_string(state.type_report, typearg.constraint)
+                constraint = typearg_constraint_to_string(
+                    state.type_report,
+                    typearg.constraint
+                )
             }
         end
 
@@ -494,7 +515,10 @@ local function item_for_function_type(t: tl.FunctionType | tl.GenericType, visib
     if t.args and #t.args.tuple > 0 then
         item.params = {}
         for i, ar in ipairs(t.args.tuple) do
-            if t.is_method and i == 1 then
+            if i == 1
+                and owner
+                and (t.is_method or is_generic and ar.typename == "self")
+            then
                 -- The receiver carries no name of its own in a declaration.
                 -- Name it as a definition would, so both spellings of the same
                 -- method document the same parameters.


### PR DESCRIPTION
Some public APIs keep mutually dependent declarations in one source module but publish them under different namespaces. API pages can now select direct declarations from a source and assign that source its own public prefix.

This also keeps constrained generic record methods intact with current Teal type reports. A method such as `get<T is Component>(self, entity, component)` retains its receiver, parameter order, and constraint in generated documentation.

Validation:

- `make build`
- selected API projection site spec
- constrained generic record method specs
- Tecs site build with `tecs.World`, `tecs.Query`, `tecs.System`, and `tecs.Plugin` projected onto the `tecs.ecs` page