### PR TITLE
Bind a type argument's description by the name it gives

### DIFF
--- a/spec/parser/teal/typeargs_spec.lua
+++ b/spec/parser/teal/typeargs_spec.lua
@@ -1,0 +1,36 @@
+local util = require("spec.util")
+
+describe("teal support in tealdoc: type arguments", function()
+    it("should describe each type argument by the name its tag gives", function()
+        -- The tags are written in the opposite order to the declaration. A
+        -- handler binding by position would put each description on the
+        -- wrong parameter, or drop one and keep the other.
+        local registry = util.registry_for_text(util.dedent([[
+            --- my function
+            --- @typearg V what comes out
+            --- @typearg K what goes in
+            local function lookup<K, V>(key: K): V
+            end
+        ]]))
+        assert.are.same(
+            {
+                { name = "K", description = "what goes in" },
+                { name = "V", description = "what comes out" },
+            },
+            registry["$test~lookup"].typeargs
+        )
+    end)
+
+    it("should describe a type argument the compiler leaves unnamed", function()
+        local registry = util.registry_for_text(util.dedent([[
+            --- my function
+            --- @typearg T the only one
+            local function only<T>(value: T): T
+            end
+        ]]))
+        assert.are.same(
+            { { name = "T", description = "the only one" } },
+            registry["$test~only"].typeargs
+        )
+    end)
+end)

--- a/src/tealdoc/default_env.tl
+++ b/src/tealdoc/default_env.tl
@@ -103,7 +103,7 @@ function DefaultEnv.init(): tealdoc.Env
         end
     }
 
-    local typearg_tag_handler: tealdoc.Tag = { -- TODO: improve!
+    local typearg_tag_handler: tealdoc.Tag = {
         name = "typearg",
         has_param = true,
         has_description = true,
@@ -119,30 +119,33 @@ function DefaultEnv.init(): tealdoc.Env
                 return
             end
 
+            -- A tag says which parameter it describes, so it is bound by
+            -- that name. Binding by position instead meant the tags had to
+            -- be written in declaration order, and a pair written the other
+            -- way round was noticed and then thrown away rather than put
+            -- where it belonged.
             local typearg: tealdoc.Typearg
             if item.typeargs then
-                for _, t in ipairs(item.typeargs) do
-                    if t.description == nil then
-                        typearg = t
+                for _, candidate in ipairs(item.typeargs) do
+                    if candidate.name == ctx.param then
+                        typearg = candidate
                         break
+                    end
+                end
+                if not typearg then
+                    -- A parameter the compiler reported without a name can
+                    -- still be described; the first undescribed one is it.
+                    for _, candidate in ipairs(item.typeargs) do
+                        if not candidate.name and candidate.description == nil then
+                            typearg = candidate
+                            break
+                        end
                     end
                 end
             end
             if not typearg then
                 log:warning(
-                    "Found more @typearg tags than declared type arguments in '%s' (%s:%s:%s)",
-                    item.name,
-                    item.location.filename,
-                    item.location.y,
-                    item.location.x
-                )
-                return
-            end
-
-            if typearg.name and typearg.name ~= ctx.param then
-                log:warning(
-                    "Typearg name mismatch: expected '%s', got '%s' in '%s' (%s:%s:%s)",
-                    typearg.name,
+                    "No type argument named '%s' is declared by '%s' (%s:%s:%s)",
                     ctx.param,
                     item.name,
                     item.location.filename,
@@ -150,6 +153,16 @@ function DefaultEnv.init(): tealdoc.Env
                     item.location.x
                 )
                 return
+            end
+            if typearg.description ~= nil then
+                log:warning(
+                    "Type argument '%s' of '%s' is described twice (%s:%s:%s)",
+                    ctx.param,
+                    item.name,
+                    item.location.filename,
+                    item.location.y,
+                    item.location.x
+                )
             end
             typearg.name = ctx.param
             typearg.description = ctx.description


### PR DESCRIPTION
The tag says which parameter it describes and the handler ignored it, taking the first parameter still undescribed and then checking the name only to complain. Tags written in an order other than the declaration's were noticed and thrown away, so a generic with two parameters documented back to front lost one of them and kept the wrong one.

Against `<K, V>` with the tags written `V` then `K`, before and after:

```
 before   K -> what goes in    V -> nil
 after    K -> what goes in    V -> what comes out
```

A parameter the compiler reports without a name is still matched by position, since there is nothing else to match on.