### PR TITLE
Resolve a highlighted type by the path it is written under

### DIFF
--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -470,19 +470,38 @@ describe("Site generator", function()
         env.no_warnings_on_missing = true
         tealdoc.process_text([[
             local record internal
-                --- A shape a public module re-exports.
-                record Circle
-                    radius: number
+                --- A shape only its public alias documents.
+                type Circle = {radius: number}
+
+                record Event
                 end
+
+                --- A listener only its public alias documents.
+                type EventListener = function<E is Event>(event: E)
             end
 
             return internal
         ]], "internal.tl", env)
         tealdoc.process_text([[
+            local record targets
+                --- A listener with its own public definition.
+                type Listener = function(message: string)
+            end
+
+            return targets
+        ]], "targets.tl", env)
+        tealdoc.process_text([[
             local type internal = require("internal")
+            local type targets = require("targets")
             local record shapes
                 --- The shape, under the name the site publishes it as.
                 type Circle = internal.Circle
+
+                --- A private listener rendered as its concrete function type.
+                type EventListener = internal.EventListener
+
+                --- A public listener linked to its definition.
+                type Listener = targets.Listener
 
                 --- Grows one.
                 grow: function(circle: Circle): Circle
@@ -510,6 +529,12 @@ describe("Site generator", function()
                     api = "shapes",
                     public = "public.shapes",
                 },
+                {
+                    path = "targets",
+                    title = "targets",
+                    api = "targets",
+                    public = "public.targets",
+                },
             },
         })
 
@@ -531,16 +556,39 @@ describe("Site generator", function()
             true
         ), guide_html)
 
-        -- The declaration a re-export renders as is where this reads worst:
-        -- both sides are spelled `Circle`, and linking the right one by its
-        -- last segment points the reader at the left one.
+        -- Authored code still says what it says: the source path is private
+        -- and therefore has nowhere honest to link.
+        --
+        -- A generated declaration is different. Tealdoc knows that it is an
+        -- alias and can say what a private target means instead of publishing
+        -- an internal spelling.
         local shapes_html = read_file(output .. "/shapes/index.html")
+        local shapes_markdown = read_file(output .. "/shapes.md")
+        assert.is_falsy(shapes_markdown:find(
+            "type public.shapes.Circle = internal.Circle",
+            1,
+            true
+        ), shapes_markdown)
+        assert.is_truthy(shapes_markdown:find(
+            "type public.shapes.Circle = {radius : number}",
+            1,
+            true
+        ), shapes_markdown)
+        assert.is_truthy(shapes_markdown:find(
+            "type public.shapes.EventListener = " ..
+                "function<E is Event>(E)",
+            1,
+            true
+        ), shapes_markdown)
+
+        -- A target another page documents keeps the alias spelling and links
+        -- through the import name to that target rather than to this page's
+        -- same-named declaration.
         assert.is_truthy(shapes_html:find(
-            '<span class="token variable tealdoc-token-variable">internal' ..
-                '</span><span class="token punctuation ' ..
-                'tealdoc-token-punctuation">.</span>' ..
+            '<a class="tealdoc-code-link" ' ..
+                'href="/targets/#public.targets.Listener">' ..
                 '<span class="token class-name tealdoc-token-type">' ..
-                "Circle</span>",
+                "Listener</span></a>",
             1,
             true
         ), shapes_html)

--- a/spec/generator/site_spec.lua
+++ b/spec/generator/site_spec.lua
@@ -13,6 +13,19 @@ local function read_file(path)
     return contents
 end
 
+local function count_occurrences(haystack, needle)
+    local found = 0
+    local cursor = 1
+    while true do
+        local first, last = haystack:find(needle, cursor, true)
+        if not first then
+            return found
+        end
+        found = found + 1
+        cursor = last + 1
+    end
+end
+
 local function remove_tree(path)
     local attributes = lfs.symlinkattributes(path)
     if not attributes then
@@ -239,6 +252,51 @@ describe("Site generator", function()
         assert.is_falsy(declaration:find("tealdoc-code-link", 1, true))
     end)
 
+    it("links a qualified type by the whole path it is written under",
+        function()
+            local links = {
+                Window = "/modules/window/",
+                ["shell.Window"] = "/modules/shell/#shell.Window",
+            }
+
+            -- The qualifier decides, so the two spellings answer differently
+            -- and neither answers for the other.
+            local qualified = Highlighter.highlight(
+                "local frame: shell.Window = nil\n",
+                links
+            )
+            assert.is_truthy(qualified:find(
+                '<a class="tealdoc-code-link" ' ..
+                    'href="/modules/shell/#shell.Window">' ..
+                    '<span class="token class-name tealdoc-token-type">' ..
+                    "Window</span></a>",
+                1,
+                true
+            ), qualified)
+
+            local bare = Highlighter.highlight(
+                "local frame: Window = nil\n",
+                links
+            )
+            assert.is_truthy(bare:find(
+                '<a class="tealdoc-code-link" href="/modules/window/">' ..
+                    '<span class="token class-name tealdoc-token-type">' ..
+                    "Window</span></a>",
+                1,
+                true
+            ), bare)
+
+            -- A path the site documents nothing under stays unlinked rather
+            -- than falling back to whatever public type shares its last
+            -- segment. `type Window = internal.platform.Window` reads as a
+            -- declaration linking to itself when it does.
+            local foreign = Highlighter.highlight(
+                "type Window = internal.platform.Window\n",
+                links
+            )
+            assert.is_falsy(foreign:find("tealdoc-code-link", 1, true), foreign)
+        end)
+
     it("labels a fenced block and highlights it through its attributes",
         function()
             local html = SiteMarkdown.render(
@@ -405,6 +463,91 @@ describe("Site generator", function()
         assert.is_falsy(html:find("#hidden.Secret", 1, true))
 
         remove_tree(output)
+    end)
+
+    it("links code by the path a type is published under", function()
+        local env = DefaultEnv.init()
+        env.no_warnings_on_missing = true
+        tealdoc.process_text([[
+            local record internal
+                --- A shape a public module re-exports.
+                record Circle
+                    radius: number
+                end
+            end
+
+            return internal
+        ]], "internal.tl", env)
+        tealdoc.process_text([[
+            local type internal = require("internal")
+            local record shapes
+                --- The shape, under the name the site publishes it as.
+                type Circle = internal.Circle
+
+                --- Grows one.
+                grow: function(circle: Circle): Circle
+            end
+
+            return shapes
+        ]], "shapes.tl", env)
+
+        local guide = os.tmpname()
+        write_file(guide, "# Guide\n\n" ..
+            "```teal\n" ..
+            "local a: public.shapes.Circle = nil\n" ..
+            "local b: internal.Circle = nil\n" ..
+            "local c: Circle = nil\n" ..
+            "```\n")
+        local output = os.tmpname()
+        os.remove(output)
+        SiteGenerator.build(output, env, {
+            title = "Shapes",
+            pages = {
+                {path = "", title = "Home", source = guide},
+                {
+                    path = "shapes",
+                    title = "shapes",
+                    api = "shapes",
+                    public = "public.shapes",
+                },
+            },
+        })
+
+        local link = '<a class="tealdoc-code-link" ' ..
+            'href="/shapes/#public.shapes.Circle">' ..
+            '<span class="token class-name tealdoc-token-type">' ..
+            "Circle</span></a>"
+        local guide_html = read_file(output .. "/index.html")
+        -- The published path and the bare name, and nothing for the source
+        -- path the site says nothing about.
+        assert.are.equal(2, count_occurrences(guide_html, link), guide_html)
+        assert.is_truthy(guide_html:find(
+            '<span class="token property tealdoc-token-property">internal' ..
+                '</span><span class="token punctuation ' ..
+                'tealdoc-token-punctuation">.</span>' ..
+                '<span class="token class-name tealdoc-token-type">' ..
+                "Circle</span>",
+            1,
+            true
+        ), guide_html)
+
+        -- The declaration a re-export renders as is where this reads worst:
+        -- both sides are spelled `Circle`, and linking the right one by its
+        -- last segment points the reader at the left one.
+        local shapes_html = read_file(output .. "/shapes/index.html")
+        assert.is_truthy(shapes_html:find(
+            '<span class="token variable tealdoc-token-variable">internal' ..
+                '</span><span class="token punctuation ' ..
+                'tealdoc-token-punctuation">.</span>' ..
+                '<span class="token class-name tealdoc-token-type">' ..
+                "Circle</span>",
+            1,
+            true
+        ), shapes_html)
+        assert.are.equal(2, count_occurrences(shapes_html, link), shapes_html)
+
+        remove_tree(output)
+        os.remove(guide)
     end)
 
     it("carries a union type through a parameter table to the page", function()

--- a/src/tealdoc/generator.tl
+++ b/src/tealdoc/generator.tl
@@ -62,6 +62,9 @@ local record Generator
             filter: function(item: tealdoc.Item, env: tealdoc.Env): boolean
             url_for_path: function(path: string): string
             url_for_type: function(path: string): string
+            private_alias_target: function(
+                item: tealdoc.TypeItem
+            ): tealdoc.TypeItem
         end
 
         name: string

--- a/src/tealdoc/generator/markdown.tl
+++ b/src/tealdoc/generator/markdown.tl
@@ -270,6 +270,12 @@ local record MarkdownGenerator
         type_url_for_path: URLResolver,
         allow_local_type_links?: boolean
     ): string
+    private_alias_target: function(
+        env: tealdoc.Env,
+        item: tealdoc.TypeItem,
+        type_url_for_path: URLResolver,
+        allow_local_type_links?: boolean
+    ): tealdoc.TypeItem
     item_phases: {string: {Generator.Phase}}
 end
 
@@ -289,9 +295,13 @@ function MarkdownGenerator.resolve_type_url(
             return type_url_for_path(path)
         end
         if Generator.filter(item, env) then
-            return type_url_for_path(path)
-                or allow_local_type_links ~= false and "#" .. path
-                or nil
+            local url = type_url_for_path(path)
+            if url then
+                return url
+            end
+            if allow_local_type_links ~= false then
+                return "#" .. path
+            end
         end
         if item is tealdoc.TypeItem
             and item.type_kind == "type"
@@ -301,6 +311,50 @@ function MarkdownGenerator.resolve_type_url(
         else
             return nil
         end
+    end
+    return nil
+end
+
+--- Finds the concrete private alias whose type expression should replace a
+--- public alias's nominal right-hand side.
+---
+--- A target with a URL remains a nominal expression for the highlighter to
+--- link. Without one, following private aliases until the first structural
+--- expression lets a declaration say what the public name actually means.
+--- Records, interfaces and enums keep their nominal spelling: expanding one
+--- requires projecting its children, not replacing one expression.
+function MarkdownGenerator.private_alias_target(
+    env: tealdoc.Env,
+    item: tealdoc.TypeItem,
+    type_url_for_path: MarkdownGenerator.URLResolver,
+    allow_local_type_links?: boolean
+): tealdoc.TypeItem
+    if not item.alias_target
+        or MarkdownGenerator.resolve_type_url(
+            env,
+            item.alias_target,
+            type_url_for_path,
+            allow_local_type_links
+        )
+    then
+        return nil
+    end
+
+    local seen: {string: boolean} = {}
+    local path = item.alias_target
+    while path and not seen[path] do
+        seen[path] = true
+        local target = env.registry[path]
+        if not target
+            or not target is tealdoc.TypeItem
+            or target.type_kind ~= "type"
+        then
+            return nil
+        end
+        if not target.alias_target then
+            return target
+        end
+        path = target.alias_target
     end
     return nil
 end
@@ -336,6 +390,16 @@ local function generator_for(
                 return MarkdownGenerator.resolve_type_url(
                     env,
                     path,
+                    type_url_for_path,
+                    allow_local_type_links
+                )
+            end
+            ctx.private_alias_target = function(
+                item: tealdoc.TypeItem
+            ): tealdoc.TypeItem
+                return MarkdownGenerator.private_alias_target(
+                    env,
+                    item,
                     type_url_for_path,
                     allow_local_type_links
                 )

--- a/src/tealdoc/generator/signatures.tl
+++ b/src/tealdoc/generator/signatures.tl
@@ -97,12 +97,22 @@ end
 function signatures.for_type(ctx: Generator.Phase.Context, item: tealdoc.TypeItem)
     ctx.builder:text(attr("name"), visibility(item), item.type_kind, " ", function () ctx.builder:link(item.path, get_name(ctx, item)) end)
     if item.type_kind == "type" then
+        local private_target = ctx.private_alias_target
+            and ctx.private_alias_target(item)
+        local typename = private_target and private_target.typename
+            or item.typename
         ctx.builder:text(attr("type"), " = ", function()
-            local url = item.alias_target and ctx.url_for_path and ctx.url_for_path(item.alias_target)
+            local url = not private_target
+                and item.alias_target
+                and (
+                    ctx.url_for_type and ctx.url_for_type(item.alias_target)
+                    or ctx.url_for_path
+                        and ctx.url_for_path(item.alias_target)
+                )
             if url then
-                ctx.builder:link_url(url, item.typename)
+                ctx.builder:link_url(url, typename)
             else
-                ctx.builder:text(item.typename)
+                ctx.builder:text(typename)
             end
         end)
     elseif item.typeargs and #item.typeargs > 0 then

--- a/src/tealdoc/generator/site.tl
+++ b/src/tealdoc/generator/site.tl
@@ -2341,7 +2341,13 @@ function SiteGenerator.build(
     local resolver = routes_for_pages(context.pages, views, settings.base)
     -- Built once for the whole site: it is the same table every time and
     -- walking the registry is not free.
-    local site_links = SiteApi.site_type_links(env, resolver)
+    local public_paths: {string: string} = {}
+    for _, view in pairs(views) do
+        for source_path, public_path in pairs(view.source_to_public) do
+            public_paths[source_path] = public_path
+        end
+    end
+    local site_links = SiteApi.site_type_links(env, resolver, public_paths)
     local search_entries: {SearchEntry} = {}
     local page_markdown: {string} = {}
     for _, page in ipairs(context.pages) do

--- a/src/tealdoc/generator/site/api.tl
+++ b/src/tealdoc/generator/site/api.tl
@@ -139,6 +139,26 @@ local function add_type_link(
     add_spelling(links, ambiguous, name:match("([%w_]+)$"), url)
 end
 
+--- The nominal spelling on an alias's right-hand side. `typename` may carry
+--- generic arguments around it, while the highlighter looks up only the
+--- dotted identifier ending at the type token.
+local function alias_spelling(item: tealdoc.TypeItem): string
+    if not item.alias_target then
+        return nil
+    end
+    local target_name = item.alias_target:match("([%w_]+)$")
+    local unqualified: string
+    for candidate in item.typename:gmatch("[%a_][%w_%.]*") do
+        if candidate:match("([%w_]+)$") == target_name then
+            if candidate:find(".", 1, true) then
+                return candidate
+            end
+            unqualified = unqualified or candidate
+        end
+    end
+    return unqualified
+end
+
 function SiteApi.type_links(
     view: SiteTypes.ApiView,
     resolver: MarkdownGenerator.URLResolver
@@ -171,6 +191,21 @@ function SiteApi.type_links(
             -- block writes it under.
             add_type_link(links, ambiguous, item.name, resolver(path))
             add_type_link(links, ambiguous, path, resolver(path))
+            local target_url = item.alias_target
+                and MarkdownGenerator.resolve_type_url(
+                    env,
+                    item.alias_target,
+                    resolver,
+                    false
+                )
+            if target_url then
+                add_spelling(
+                    links,
+                    ambiguous,
+                    alias_spelling(item),
+                    target_url
+                )
+            end
         elseif item and item is tealdoc.FunctionItem then
             for _, param in ipairs(item.params or {}) do
                 for _, reference in ipairs(param.type_references or {}) do

--- a/src/tealdoc/generator/site/api.tl
+++ b/src/tealdoc/generator/site/api.tl
@@ -15,7 +15,8 @@ local record SiteApi
     --- a page falls back to rather than what it starts from.
     site_type_links: function(
         env: tealdoc.Env,
-        resolver: MarkdownGenerator.URLResolver
+        resolver: MarkdownGenerator.URLResolver,
+        public_paths?: {string: string}
     ): Highlighter.Links
     markdown: function(
         view: SiteTypes.ApiView,
@@ -82,6 +83,40 @@ function SiteApi.source_markdown(page: SiteTypes.Page): string
     return text
 end
 
+--- One spelling against one type, and nothing against a spelling two types
+--- answer to. A highlighted token is looked up under the whole dotted
+--- expression it ends rather than its last segment, so what is registered here
+--- is what a code block may write and mean this type.
+local function add_spelling(
+    links: Highlighter.Links,
+    ambiguous: {string: boolean},
+    spelling: string,
+    url: string
+)
+    if not spelling or spelling == "" or not url then
+        return
+    end
+    if ambiguous[spelling] then
+        return
+    end
+    if links[spelling] and links[spelling] ~= url then
+        links[spelling] = nil
+        ambiguous[spelling] = true
+    else
+        links[spelling] = url
+    end
+end
+
+--- A qualified name and every shorter tail of it: `tecs.gfx.Camera` registers
+--- itself, `gfx.Camera` and `Camera`. Code inside a module writes a type under
+--- as much of its path as the enclosing scope leaves it needing, and a page is
+--- the scope its own names are relative to, so all three mean this one type
+--- there.
+---
+--- Site-wide this is not true, which is why the site's map registers exact
+--- names instead. `events.Event` is the ECS event on the page documenting it
+--- and the platform event on the page documenting that one, and a tail nobody
+--- qualified is a guess between them.
 local function add_type_link(
     links: Highlighter.Links,
     ambiguous: {string: boolean},
@@ -91,22 +126,17 @@ local function add_type_link(
     if not name or name == "" or not url then
         return
     end
-    local function add(candidate: string)
-        if ambiguous[candidate] then
-            return
+    add_spelling(links, ambiguous, name, url)
+    local tail = name
+    while true do
+        local shorter = tail:match("^[%w_]+%.(.+)$")
+        if not shorter then
+            break
         end
-        if links[candidate] and links[candidate] ~= url then
-            links[candidate] = nil
-            ambiguous[candidate] = true
-        else
-            links[candidate] = url
-        end
+        tail = shorter
+        add_spelling(links, ambiguous, tail, url)
     end
-    add(name)
-    local basename = name:match("([%w_]+)$")
-    if basename and basename ~= name then
-        add(basename)
-    end
+    add_spelling(links, ambiguous, name:match("([%w_]+)$"), url)
 end
 
 function SiteApi.type_links(
@@ -136,7 +166,11 @@ function SiteApi.type_links(
             and path ~= view.public
             and Generator.filter(item, env)
         then
+            -- A page's registry is keyed by public path, so `path` is the
+            -- spelling the documentation gives this type and the one a code
+            -- block writes it under.
             add_type_link(links, ambiguous, item.name, resolver(path))
+            add_type_link(links, ambiguous, path, resolver(path))
         elseif item and item is tealdoc.FunctionItem then
             for _, param in ipairs(item.params or {}) do
                 for _, reference in ipairs(param.type_references or {}) do
@@ -236,18 +270,38 @@ end
 --- pages are rendered from.
 ---
 --- A name two modules both declare resolves to neither. That is
---- `add_type_link`'s rule, and it matters more here than on a page, where a
+--- `add_spelling`'s rule, and it matters more here than on a page, where a
 --- name is usually unambiguous inside one module and only collides across the
 --- site: `Event` is three different records.
+---
+--- `public_paths` carries a source path to the path the site publishes it
+--- under, because this registry is the one the parser filled and its keys are
+--- where a type is declared rather than where a reader reaches it. The public
+--- path is the qualified spelling registered, and the source path is not: a
+--- route through internals is not something a page describes, and a reader
+--- who follows one arrives at a page that never mentions it.
+---
+--- Only the whole public path and the bare name, with nothing in between. A
+--- page carries the scope its own shorter spellings are relative to and
+--- `type_links` registers those; a page reaching another module's type has no
+--- such scope, and a tail like `Window.Options` names one type on the window
+--- page and is a coincidence anywhere else.
 function SiteApi.site_type_links(
     env: tealdoc.Env,
-    resolver: MarkdownGenerator.URLResolver
+    resolver: MarkdownGenerator.URLResolver,
+    public_paths?: {string: string}
 ): Highlighter.Links
     local links: Highlighter.Links = {}
     local ambiguous: {string: boolean} = {}
     for path, item in pairs(env.registry) do
         if item is tealdoc.TypeItem and Generator.filter(item, env) then
-            add_type_link(links, ambiguous, item.name, resolver(path))
+            add_spelling(links, ambiguous, item.name, resolver(path))
+            add_spelling(
+                links,
+                ambiguous,
+                public_paths and public_paths[path],
+                resolver(path)
+            )
         end
     end
     return links

--- a/src/tealdoc/generator/site/highlighter.tl
+++ b/src/tealdoc/generator/site/highlighter.tl
@@ -147,6 +147,25 @@ local function is_declaration_name(tokens: {tl.Token}, index: integer): boolean
     return false
 end
 
+--- The whole dotted expression a type token ends, so `EventListener` read
+--- from `types.events.EventListener` answers all three segments. A qualified
+--- name is not its last segment: the two name different types as often as
+--- they name the same one, and the link map holds the basename of every
+--- documented type, so looking one up by its final token alone finds an
+--- unrelated public type and links to it.
+local function qualified_name(tokens: {tl.Token}, index: integer): string
+    local name = tokens[index].tk
+    local cursor = index - 1
+    while cursor > 1
+        and tokens[cursor].tk == "."
+        and tokens[cursor - 1].kind == "identifier"
+    do
+        name = tokens[cursor - 1].tk .. "." .. name
+        cursor = cursor - 2
+    end
+    return name
+end
+
 function Highlighter.highlight(code: string, links?: Highlighter.Links): string
     local offsets: {integer} = {1}
     for position = 1, #code do
@@ -176,7 +195,7 @@ function Highlighter.highlight(code: string, links?: Highlighter.Links): string
                     and not is_declaration_name(tokens, index)
                     and links
                 then
-                    url = links[token.tk]
+                    url = links[qualified_name(tokens, index)]
                 end
                 table.insert(segments, {
                     first = first,


### PR DESCRIPTION
A rendered code block used to link a type by the last segment of whatever expression it appeared in. A qualified name therefore reached whichever public type happened to share its final token. On a module page that re-exported a type, `type EventListener = types.events.EventListener` linked the right-hand side back to the alias being declared.

That exposed a second problem once the false self-link was removed: Tealdoc already knew the canonical alias target, but generated site signatures did not use it. A public target should link to its documented definition, while a private type alias should contribute its concrete type expression rather than expose an internal path.

## What changed

`Highlighter.highlight` now looks a token up under the whole dotted expression it ends rather than its final token. The page and site link maps register the qualified public spellings that code can actually write.

Alias rendering now also uses the canonical target recorded by the parser:

- When the target has a site route, the generated declaration keeps its nominal spelling and links that spelling to the target definition.
- When the target has no route, Tealdoc follows private type aliases until it reaches a concrete type expression and renders that expression inline.
- Alias chains continue through an intermediate visible alias that has no route of its own.
- Records, interfaces, and enums remain nominal because expanding those requires projecting their children rather than substituting a single type expression.

The motivating declaration now renders the private target as its concrete function type instead of linking to itself or leaving `types.events.EventListener` as unexplained text.

## Tests

The end-to-end site spec covers both outcomes in one generated site:

- a public alias target on another page is linked through the import spelling used by the declaration;
- private map and generic function aliases are inlined without exposing their internal module paths;
- authored code that names an undocumented private path remains unlinked;
- qualified public paths, page-relative paths, and bare unambiguous names still link correctly.

A highlighter unit test separately covers qualified lookup, unqualified lookup, and an unknown qualified path that must stay unlinked.